### PR TITLE
Add a bit of doc

### DIFF
--- a/doc/compression_opts.rst
+++ b/doc/compression_opts.rst
@@ -1,0 +1,55 @@
+=====================
+ Compression options
+=====================
+
+Compression filters can be configured with the ``compression_opts`` argument of `h5py.Group.create_dataset <http://docs.h5py.org/en/stable/high/group.html#Group.create_dataset>`_ method by providing a tuple of integers.
+
+The meaning of those integers is filter dependent and is described below.
+
+bitshuffle
+..........
+
+compression_opts: (**block_size**, **lz4 compression**)
+
+- **block size**: Number of elements (not bytes) per block.
+  It MUST be a mulitple of 8.
+  Default: 0 for a block size of about 8 kB.
+- **lz4 compression**: 0: disabled (default), 2: enabled.
+
+By default the filter uses bitshuffle, but do NOT compress with LZ4.
+
+blosc
+.....
+
+compression_opts: (0, 0, 0, 0, **compression level**, **shuffle**, **compression**)
+
+- First 4 values are reserved.
+- **compression level**:
+  From 0 (no compression) to 9 (maximum compression).
+  Default: 5.
+- **shuffle**: Shuffle filter:
+
+  * 0: no shuffle
+  * 1: byte shuffle
+  * 2: bit shuffle
+
+- **compression**: The compressor blosc ID:
+
+  * 0: blosclz (default)
+  * 1: lz4
+  * 2: lz4hc
+  * 3: snappy
+  * 4: zlib
+  * 5: zstd
+
+By default the filter uses byte shuffle and blosclz.
+
+lz4
+...
+
+compression_opts: (**block_size**,)
+
+- **block size**: Number of bytes per block.
+  Default 0 for a block size of 1GB.
+  It MUST be < 1.9 GB.
+

--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -10,37 +10,37 @@ Guidelines to add a compression filter
 This briefly describes the steps to add a HDF5 compression filter to the zoo.
 
 * Add the source of the HDF5 filter and compression algorithm code in a subdirectory in `src/[filter]`.
-  Best is to use `git subtree` else copy the files there (including the license file).
+  Best is to use ``git subtree`` else copy the files there (including the license file).
   A released version of the filter + compression libraru should be used.
 
-  `git subtree` command::
+  ``git subtree`` command::
 
     git subtree add --prefix=src/[filter]  [git repository]  [release tag] --squash
 
-* Update `setup.py` to build the filter dynamic library by adding an extension using the `HDF5PluginExtension` class (a subclass of `setuptools.Extension`) which adds extra files and compile options to enable dynamic loading of the filter.
-  The name of the extension should be `hdf5plugin.plugins.libh5<filter_name>`.
+* Update ``setup.py`` to build the filter dynamic library by adding an extension using the ``HDF5PluginExtension`` class (a subclass of ``setuptools.Extension``) which adds extra files and compile options to enable dynamic loading of the filter.
+  The name of the extension should be ``hdf5plugin.plugins.libh5<filter_name>``.
 
-* Add a "CONSTANT" in `hdf5plugins/__init__.py` named with the `FILTER_NAME` which value is the HDF5 filter ID
+* Add a "CONSTANT" in ``hdf5plugins/__init__.py`` named with the ``FILTER_NAME`` which value is the HDF5 filter ID
   (See `HDF5 registered filters <https://portal.hdfgroup.org/display/support/Registered+Filters>`_).
 
-* Add a `"<filter_name>": <FILTER_ID_CONSTANT>` entry in `hdf5plugin.FILTERS`.
-  You must use the same `filter_name` as in the extension in `setup.py` (without the `libh5` prefix) .
-  The names in `FILTERS` are used to find the available filter libraries.
+* Add a ``"<filter_name>": <FILTER_ID_CONSTANT>`` entry in `hdf5plugin.FILTERS`.
+  You must use the same `filter_name` as in the extension in ``setup.py`` (without the ``libh5`` prefix) .
+  The names in ``FILTERS`` are used to find the available filter libraries.
 
-* Add a compression options helper function named `<filter_name>_options` in `hdf5plugins/__init__.py` which should returns a dictionary containing the values for the `compression` and `compression_opts` arguments of `h5py.Group.create_dataset`.
-  This is intended to ease the usage of `compression_opts`.
+* Add a compression options helper function named ``<filter_name>_options`` in ``hdf5plugins/__init__.py`` which should returns a dictionary containing the values for the ``compression`` and ``compression_opts`` arguments of ``h5py.Group.create_dataset``.
+  This is intended to ease the usage of ``compression_opts``.
 
 * Add tests:
 
-  - In `test/test.py` for testing reading a compressed file that was produced with another software.
-  - In `hdf5plugin/test.py` for tests that writes data using the compression filter and the compression options helper function and reads back the data.
+  - In ``test/test.py`` for testing reading a compressed file that was produced with another software.
+  - In ``hdf5plugin/test.py`` for tests that writes data using the compression filter and the compression options helper function and reads back the data.
 
-* Update the `README.rst` file to document:
+* Update the ``README.rst`` file to document:
 
-  - The version of the HDF5 filter that is embedded in `hdf5plugin`.
+  - The version of the HDF5 filter that is embedded in ``hdf5plugin``.
   - The license of the filter (by adding a link to the license file).
-  - The `hdf5plugin.<FILTER_NAME>` filter ID "CONSTANT".
-  - The `hdf5plugin.<filter_name>_options` compression helper function.
+  - The ``hdf5plugin.<FILTER_NAME>`` filter ID "CONSTANT".
+  - The ``hdf5plugin.<filter_name>_options`` compression helper function.
 
-* Update `doc/compression_opts.rst` to document the format of `compression_opts` expected by the filter.
+* Update ``doc/compression_opts.rst`` to document the format of ``compression_opts`` expected by the filter.
 

--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -1,0 +1,44 @@
+==============
+ Contributing
+==============
+
+This project follows the standard open-source project github workflow, which is described in other projects like `matplotlib <https://matplotlib.org/devel/contributing.html#contributing-code>`_ or `scikit-image <https://scikit-image.org/docs/dev/contribute.html>`_.
+
+Guidelines to add a compression filter
+======================================
+
+This briefly describes the steps to add a HDF5 compression filter to the zoo.
+
+* Add the source of the HDF5 filter and compression algorithm code in a subdirectory in `src/[filter]`.
+  Best is to use `git subtree` else copy the files there (including the license file).
+  A released version of the filter + compression libraru should be used.
+
+  `git subtree` command::
+
+    git subtree add --prefix=src/[filter]  [git repository]  [release tag] --squash
+
+* Update `setup.py` to build the filter dynamic library by adding an extension using the `HDF5PluginExtension` class (a subclass of `setuptools.Extension`) which adds extra files and compile options to enable dynamic loading of the filter.
+  The name of the extension should be `hdf5plugin.plugins.libh5<filter_name>`.
+
+* Add a "CONSTANT" in `hdf5plugins/__init__.py` named with the `FILTER_NAME` which value is the HDF5 filter ID
+  (See `HDF5 registered filters <https://portal.hdfgroup.org/display/support/Registered+Filters>`_).
+
+* Add a `"<filter_name>": <FILTER_ID_CONSTANT>` entry in `hdf5plugin.FILTERS`.
+  You must use the same `filter_name` as in the extension in `setup.py` (without the `libh5` prefix) .
+  The names in `FILTERS` are used to find the available filter libraries.
+
+* Add a compression options helper function named `<filter_name>_options` in `hdf5plugins/__init__.py` which should returns a dictionary containing the values for the `compression` and `compression_opts` arguments of `h5py.Group.create_dataset`.
+  This is intended to ease the usage of `compression_opts`.
+
+* Add tests:
+
+  - In `test/test.py` for testing reading a compressed file that was produced with another software.
+  - In `hdf5plugin/test.py` for tests that writes data using the compression filter and the compression options helper function and reads back the data.
+
+* Update the `README.rst` file to document:
+
+  - The version of the HDF5 filter that is embedded in `hdf5plugin`.
+  - The license of the filter (by adding a link to the license file).
+  - The `hdf5plugin.<FILTER_NAME>` filter ID "CONSTANT".
+  - The `hdf5plugin.<filter_name>_options` compression helper function.
+

--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -42,3 +42,5 @@ This briefly describes the steps to add a HDF5 compression filter to the zoo.
   - The `hdf5plugin.<FILTER_NAME>` filter ID "CONSTANT".
   - The `hdf5plugin.<filter_name>_options` compression helper function.
 
+* Update `doc/compression_opts.rst` to document the format of `compression_opts` expected by the filter.
+

--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -9,7 +9,7 @@ Guidelines to add a compression filter
 
 This briefly describes the steps to add a HDF5 compression filter to the zoo.
 
-* Add the source of the HDF5 filter and compression algorithm code in a subdirectory in `src/[filter]`.
+* Add the source of the HDF5 filter and compression algorithm code in a subdirectory in ``src/[filter]``.
   Best is to use ``git subtree`` else copy the files there (including the license file).
   A released version of the filter + compression libraru should be used.
 
@@ -23,7 +23,7 @@ This briefly describes the steps to add a HDF5 compression filter to the zoo.
 * Add a "CONSTANT" in ``hdf5plugins/__init__.py`` named with the ``FILTER_NAME`` which value is the HDF5 filter ID
   (See `HDF5 registered filters <https://portal.hdfgroup.org/display/support/Registered+Filters>`_).
 
-* Add a ``"<filter_name>": <FILTER_ID_CONSTANT>`` entry in `hdf5plugin.FILTERS`.
+* Add a ``"<filter_name>": <FILTER_ID_CONSTANT>`` entry in ``hdf5plugin.FILTERS``.
   You must use the same `filter_name` as in the extension in ``setup.py`` (without the ``libh5`` prefix) .
   The names in ``FILTERS`` are used to find the available filter libraries.
 


### PR DESCRIPTION
This PR adds a little bit of documentation on how-to add a compression filter to the zoo and keeps the compression_opts tuple documentation in a rst document as it was removed from the README.