### PR TITLE
Update helper

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ hdf5plugin
 This module provides HDF5 compression filters (namely: blosc, bitshuffle and lz4) and registers them to the HDF5 library used by `h5py <https://www.h5py.org>`_.
 
 * Supported operating systems: Linux, Windows, macOS.
-* Supported version of Python: 2.7 and 3.4 to 3.8
+* Supported versions of Python: 2.7 and >= 3.4
 
 `hdf5plugin` provides a generic way to enable the use of the provided HDF5 compression filters with `h5py`.
 HDF5 compression filters can be also be installed either system-wide on Linux or through Anaconda (`blosc-hdf5-plugin <https://anaconda.org/conda-forge/blosc-hdf5-plugin>`_, `hdf5-lz4 <https://anaconda.org/nsls2forge/hdf5-lz4>`_)

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Sample code:
 * Compression option helper classes to prepare arguments to provide to ``h5py.Group.create_dataset``:
 
   - `Bitshuffle(nelems=0, lz4=True)`_
-  - `Blosc(cname='blosclz', clevel=9, shuffle=SHUFFLE)`_
+  - `Blosc(cname='lz4', clevel=5, shuffle=SHUFFLE)`_
   - `LZ4(nbytes=0)`_
 
 * ``FILTERS``: A dictionary mapping provided filters to their ID
@@ -87,20 +87,20 @@ Sample code:
         f.close()
 
 
-Blosc(cname='blosclz', clevel=9, shuffle=SHUFFLE)
-*************************************************
+Blosc(cname='lz4', clevel=5, shuffle=SHUFFLE)
+*********************************************
 
 This class takes the following arguments and returns the compression options to feed into ``h5py.Group.create_dataset`` for using the blosc filter:
 
 * **cname** the compression algorithm, one of:
 
-  * 'blosclz' (default)
-  * 'lz4'
+  * 'blosclz'
+  * 'lz4' (default)
   * 'lz4hc'
   * 'zlib'
   * 'zstd'
 
-* **clevel** the compression level, from 0 to 9 (default is 9)
+* **clevel** the compression level, from 0 to 9 (default is 5)
 * **shuffle** the shuffling mode, in:
 
   * `Blosc.NOSHUFFLE` (0): No shuffle

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Sample code:
 * Compression option helper classes to prepare arguments to provide to ``h5py.Group.create_dataset``:
 
   - `Bitshuffle(nelems=0, lz4=True)`_
-  - `Blosc(level=9, shuffle='byte', compression='blosclz')`_
+  - `Blosc(cname='blosclz', clevel=9, shuffle=SHUFFLE)`_
   - `LZ4(nbytes=0)`_
 
 * ``FILTERS``: A dictionary mapping provided filters to their ID
@@ -87,20 +87,25 @@ Sample code:
         f.close()
 
 
-Blosc(level=9, shuffle='byte', compression='blosclz')
-*****************************************************
+Blosc(cname='blosclz', clevel=9, shuffle=SHUFFLE)
+*************************************************
 
 This class takes the following arguments and returns the compression options to feed into ``h5py.Group.create_dataset`` for using the blosc filter:
 
-* **level** the compression level, from 0 to 9 (default is 9)
-* **shuffle** the shuffling mode, either 'none', 'bit' or 'byte' (default is 'byte')
-* **compression** the compressor blosc ID, one of:
+* **cname** the compression algorithm, one of:
 
   * 'blosclz' (default)
   * 'lz4'
   * 'lz4hc'
   * 'zlib'
   * 'zstd'
+
+* **clevel** the compression level, from 0 to 9 (default is 9)
+* **shuffle** the shuffling mode, in:
+
+  * `Blosc.NOSHUFFLE` (0): No shuffle
+  * `Blosc.SHUFFLE` (1): byte-wise shuffle (default)
+  * `Blosc.BITSHUFFLE` (2): bit-wise shuffle
 
 It can be passed as keyword arguments.
 
@@ -110,7 +115,7 @@ Sample code:
 
         f = h5py.File('test.h5', 'w')
         f.create_dataset('blosc_byte_shuffle_blosclz', data=numpy.arange(100),
-            **hdf5plugin.Blosc(level=9, shuffle='byte', compression='blosclz'))
+            **hdf5plugin.Blosc(cname='blosclz', clevel=9, shuffle=hdf5plugin.Blosc.SHUFFLE))
         f.close()
 
 

--- a/hdf5plugin/__init__.py
+++ b/hdf5plugin/__init__.py
@@ -110,10 +110,10 @@ class Blosc(_FilterRefClass):
     """h5py.Group.create_dataset's compression and compression_opts arguments for using blosc filter.
 
     :param str cname:
-        `blosclz` (default), `lz4`, `lz4hc`, `zlib`, `zstd`
+        `blosclz`, `lz4` (default), `lz4hc`, `zlib`, `zstd`
     :param int clevel:
         Compression level from 0 no compression to 9 maximum compression.
-        Default: 9.
+        Default: 5.
     :param int shuffle: One of:
         - Blosc.NOSHUFFLE (0): No shuffle
         - Blosc.SHUFFLE (1): byte-wise shuffle (default)
@@ -140,7 +140,7 @@ class Blosc(_FilterRefClass):
         'zstd': 5,
     }
 
-    def __init__(self, cname='blosclz', clevel=9, shuffle=SHUFFLE):
+    def __init__(self, cname='lz4', clevel=5, shuffle=SHUFFLE):
         compression = self.__COMPRESSIONS[cname]
         clevel = int(clevel)
         assert 0 <= clevel <= 9

--- a/hdf5plugin/__init__.py
+++ b/hdf5plugin/__init__.py
@@ -110,6 +110,9 @@ except AttributeError:
                 'compression_opts': self.filter_options
             }
 
+        def __hash__(self):
+            return hash((self.filter_id, self.filter_options))
+
         def __len__(self):
             return len(self._kwargs)
 

--- a/hdf5plugin/test.py
+++ b/hdf5plugin/test.py
@@ -96,21 +96,20 @@ class TestHDF5PluginRW(unittest.TestCase):
         """Write/read test with blosc filter plugin"""
         self._test('blosc')  # Default options
 
-        shuffle = ['none', 'byte', 'bit']
-        compress = ['blosclz', 'lz4', 'lz4hc', 'snappy', 'zlib', 'zstd']
         # Specify options
-        for level in range(10):
-            for shuffle_index in range(len(shuffle)):
-                for compression_index in range(6):
-                    if not compression_index == 3:
-                        filter_ = self._test(
-                            'blosc',
-                            level=level,
-                            shuffle=shuffle[shuffle_index],
-                            compression=compress[compression_index])
-                        self.assertEqual(
-                            filter_[2][4:],
-                            (level, shuffle_index, compression_index))
+        shuffles = (hdf5plugin.Blosc.NOSHUFFLE,
+                    hdf5plugin.Blosc.SHUFFLE,
+                    hdf5plugin.Blosc.BITSHUFFLE)
+        compress = 'blosclz', 'lz4', 'lz4hc', 'snappy', 'zlib', 'zstd'
+        for clevel in range(10):
+            for shuffle in shuffles:
+                for compression_id, cname in enumerate(compress):
+                    if cname == 'snappy':
+                        continue  # Not provided
+                    filter_ = self._test(
+                        'blosc', cname=cname, clevel=clevel, shuffle=shuffle)
+                    self.assertEqual(
+                        filter_[2][4:], (clevel, shuffle, compression_id))
 
     def testLZ4(self):
         """Write/read test with lz4 filter plugin"""


### PR DESCRIPTION
This PR proposes to use the same argument names and default values for the `Blosc` helper class as that of  `numcodecs.blosc.Blosc` (https://numcodecs.readthedocs.io/en/stable/blosc.html, https://github.com/zarr-developers/numcodecs/blob/master/numcodecs/blosc.pyx#L448).

There is no match for the other 2 helpers.

Also, a minor typo in the README.