### PR TITLE
Bitshuffle add option to build with OpenMP

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,13 +18,15 @@ The HDF5 plugin sources were obtained from:
 Installation
 ------------
 
-To install, just run::
+To install, run::
 
-     pip install hdf5plugin
+     pip install hdf5plugin [--user]
 
-To install locally, run::
+To install from source and recompile the HDF5 plugins, run::
 
-     pip install hdf5plugin --user
+     pip install hdf5plugin --no-binary hdf5plugin [--user]
+
+This can acheive better performances by enabling OpenMP for the bitshuffle plugin.
 
 Documentation
 -------------

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ class Build(build):
     user_options = [
         ('hdf5=', None, "Custom path to HDF5 (as in h5py)"),
         ('openmp=', None, "Whether to compile with OpenMP or not."
-         "Default: False on macOS, True otherwise")]
+         "Default: False on Windows with Python 2.7 and macOS, True otherwise")]
     user_options.extend(build.user_options)
 
     boolean_options = build.boolean_options + ['openmp']
@@ -74,7 +74,8 @@ class Build(build):
     def initialize_options(self):
         build.initialize_options(self)
         self.hdf5 = None
-        self.openmp = not sys.platform.startswith('darwin')
+        self.openmp = not sys.platform.startswith('darwin') and (
+            not sys.platform.startswith('win') or sys.version_info[0] >= 3)
 
 
 class PluginBuildExt(build_ext):


### PR DESCRIPTION
This PR adds an option to build the bitshuffle plugin with (or without) OpenMP.
It is enabled by default except on macOS.
To use the option, run: `python setup.py build --openmp=[False|True]`

closes  #24