### PR TITLE
Add snappy to blosc if c++11 is available

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,13 @@
+Unreleased
+----------
+
+- Added `--openmp=[False|True]` build option to compile bitshuffle filter with OpenMP. (PR #51)
+- Added `--sse2=[True|False]` build option to compile blosc and bitshuffle filters with SSE2 instructions if available. (PR #52)
+- Added `--avx2=[True|False]` build option to compile blosc and bitshuffle filters with AVX2 instructions if available. (PR #52)
+- Added `--native=[True|False]` build option to compile filters for native CPU architecture. This enables SSE2/AVX2 support for the bitshuffle filter if available. (PR #52)
+- Added snappy compression to the blosc filter if C++11 is available (`--cpp11=[True|False]` build option). (PR #54)
+- Improved wheel generation by using root_is_pure=True setting. (PR #49)
+
 2.0.0
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Sample code:
 
   # Compression
   f = h5py.File('test.h5', 'w')
-  f.create_dataset('data', data=numpy.arange(100), compression=hdf5plugin.LZ4_ID)
+  f.create_dataset('data', data=numpy.arange(100), **hdf5plugin.LZ4())
   f.close()
 
   # Decompression
@@ -58,17 +58,17 @@ Sample code:
 
 ``hdf5plugin`` provides:
 
-* The HDF5 filter ID of embedded plugins:
-
-  - ``BLOSC_ID``
-  - ``BSHUF_ID``
-  - ``LZ4_ID``
-
 * Compression option helper classes to prepare arguments to provide to ``h5py.Group.create_dataset``:
 
   - `Bitshuffle(nelems=0, lz4=True)`_
   - `Blosc(cname='lz4', clevel=5, shuffle=SHUFFLE)`_
   - `LZ4(nbytes=0)`_
+
+* The HDF5 filter ID of embedded plugins:
+
+  - ``BLOSC_ID``
+  - ``BSHUF_ID``
+  - ``LZ4_ID``
 
 * ``FILTERS``: A dictionary mapping provided filters to their ID
 * ``PLUGINS_PATH``: The directory where the provided filters library are stored.
@@ -104,6 +104,7 @@ This class takes the following arguments and returns the compression options to 
   * 'blosclz'
   * 'lz4' (default)
   * 'lz4hc'
+  * 'snappy' (optional, requires C++11)
   * 'zlib'
   * 'zstd'
 

--- a/hdf5plugin/__init__.py
+++ b/hdf5plugin/__init__.py
@@ -111,6 +111,7 @@ class Blosc(_FilterRefClass):
 
     :param str cname:
         `blosclz`, `lz4` (default), `lz4hc`, `zlib`, `zstd`
+        Optional: `snappy`, depending on compilation (requires C++11).
     :param int clevel:
         Compression level from 0 no compression to 9 maximum compression.
         Default: 5.
@@ -135,7 +136,7 @@ class Blosc(_FilterRefClass):
         'blosclz': 0,
         'lz4': 1,
         'lz4hc': 2,
-        # Not built 'snappy': 3,
+        'snappy': 3,
         'zlib': 4,
         'zstd': 5,
     }

--- a/hdf5plugin/test.py
+++ b/hdf5plugin/test.py
@@ -104,8 +104,6 @@ class TestHDF5PluginRW(unittest.TestCase):
         for clevel in range(10):
             for shuffle in shuffles:
                 for compression_id, cname in enumerate(compress):
-                    if cname == 'snappy':
-                        continue  # Not provided
                     filter_ = self._test(
                         'blosc', cname=cname, clevel=clevel, shuffle=shuffle)
                     self.assertEqual(

--- a/setup.py
+++ b/setup.py
@@ -370,7 +370,7 @@ define_macros.append(('HAVE_LZ4', 1))
 cpp11_kwargs = {
     'sources': glob(blosc_dir + 'internal-complibs/snappy*/*.cc'),
     'include_dirs': glob(blosc_dir + 'internal-complibs/snappy*'),
-    'extra_compile_args': ['-std=c++11', '-lstdc++'],  # TODO Windows
+    'extra_compile_args': ['-std=c++11', '-lstdc++'],
     'define_macros': [('HAVE_SNAPPY', 1)],
     }
 


### PR DESCRIPTION
This PR adds snappy to blosc if C++11 is available.
Usage of C++11 can be disabled with the `--cpp11=False` build option.

closes #41
closes #55