### PR TITLE
Add Zfp parameters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -189,6 +189,7 @@ The following compression modes are supported:
   For details, see `zfp fixed-rate mode <https://zfp.readthedocs.io/en/latest/modes.html#fixed-rate-mode>`_.
 
   .. code-block:: python
+
         f.create_dataset('zfp_fixed_rate', data=numpy.random.random(100),
             **hdf5plugin.Zfp(rate=10.0))
 
@@ -196,6 +197,7 @@ The following compression modes are supported:
   For details, see `zfp fixed-precision mode <https://zfp.readthedocs.io/en/latest/modes.html#fixed-precision-mode>`_.
 
   .. code-block:: python
+
         f.create_dataset('zfp_fixed_precision', data=numpy.random.random(100),
             **hdf5plugin.Zfp(precision=10))
 
@@ -203,6 +205,7 @@ The following compression modes are supported:
   For details, see `zfp fixed-accuracy mode <https://zfp.readthedocs.io/en/latest/modes.html#fixed-accuracy-mode>`_.
 
   .. code-block:: python
+
         f.create_dataset('zfp_fixed_accuracy', data=numpy.random.random(100),
             **hdf5plugin.Zfp(accuracy=0.001))
 
@@ -210,6 +213,7 @@ The following compression modes are supported:
   For details, see `zfp reversible mode <https://zfp.readthedocs.io/en/latest/modes.html#reversible-mode>`_.
 
   .. code-block:: python
+
         f.create_dataset('zfp_reversible', data=numpy.random.random(100),
             **hdf5plugin.Zfp(reversible=True))
 
@@ -217,7 +221,8 @@ The following compression modes are supported:
   For details, see `zfp expert mode <https://zfp.readthedocs.io/en/latest/modes.html#expert-mode>`_.
 
   .. code-block:: python
-        f.create_dataset('zfp_reversible', data=numpy.random.random(100),
+
+        f.create_dataset('zfp_expert', data=numpy.random.random(100),
             **hdf5plugin.Zfp(minbits=1, maxbits=16657, maxprec=64, minexp=-1074))
 
 Dependencies

--- a/README.rst
+++ b/README.rst
@@ -182,6 +182,44 @@ Sample code:
             **hdf5plugin.Zfp())
         f.close()
 
+The zfp filter compression mode is defined by the provided arguments.
+The following compression modes are supported:
+
+- **Fixed-rate** mode:
+  For details, see `zfp fixed-rate mode <https://zfp.readthedocs.io/en/latest/modes.html#fixed-rate-mode>`_.
+
+  .. code-block:: python
+        f.create_dataset('zfp_fixed_rate', data=numpy.random.random(100),
+            **hdf5plugin.Zfp(rate=10.0))
+
+- **Fixed-precision** mode:
+  For details, see `zfp fixed-precision mode <https://zfp.readthedocs.io/en/latest/modes.html#fixed-precision-mode>`_.
+
+  .. code-block:: python
+        f.create_dataset('zfp_fixed_precision', data=numpy.random.random(100),
+            **hdf5plugin.Zfp(precision=10))
+
+- **Fixed-accuracy** mode:
+  For details, see `zfp fixed-accuracy mode <https://zfp.readthedocs.io/en/latest/modes.html#fixed-accuracy-mode>`_.
+
+  .. code-block:: python
+        f.create_dataset('zfp_fixed_accuracy', data=numpy.random.random(100),
+            **hdf5plugin.Zfp(accuracy=0.001))
+
+- **Reversible** (i.e., lossless) mode:
+  For details, see `zfp reversible mode <https://zfp.readthedocs.io/en/latest/modes.html#reversible-mode>`_.
+
+  .. code-block:: python
+        f.create_dataset('zfp_reversible', data=numpy.random.random(100),
+            **hdf5plugin.Zfp(reversible=True))
+
+- **Expert** mode:
+  For details, see `zfp expert mode <https://zfp.readthedocs.io/en/latest/modes.html#expert-mode>`_.
+
+  .. code-block:: python
+        f.create_dataset('zfp_reversible', data=numpy.random.random(100),
+            **hdf5plugin.Zfp(minbits=1, maxbits=16657, maxprec=64, minexp=-1074))
+
 Dependencies
 ------------
 

--- a/doc/compression_opts.rst
+++ b/doc/compression_opts.rst
@@ -53,3 +53,36 @@ compression_opts: (**block_size**,)
   Default 0 for a block size of 1GB.
   It MUST be < 1.9 GB.
 
+zfp
+...
+
+For more information, see `zfp modes <https://zfp.readthedocs.io/en/latest/modes.html>`_ and `hdf5-zfp generic interface <https://h5z-zfp.readthedocs.io/en/latest/interfaces.html#generic-interface>`_.
+
+The first value of *compression_opts* is **mode**.
+The following values depends on the value of **mode**:
+
+- *Fixed-rate* mode:       (1, 0, **rateHigh**, **rateLow**, 0, 0)
+  Rate, i.e., number of compressed bits per value, as a double stored as:
+
+  - **rateHigh**: High 32-bit word of the rate double.
+  - **rateLow**: Low 32-bit word of the rate double.
+
+- *Fixed-precision* mode:  (2, 0, **prec**, 0, 0, 0)
+
+  - **prec**: Number of uncompressed bits per value.
+
+- *Fixed-accuracy* mode:   (3, 0, **accHigh**, **accLow**, 0, 0)
+  Accuracy, i.e., absolute error tolerance, as a double stored as:
+
+  - **accHigh**: High 32-bit word of the accuracy double.
+  - **accLow**: Low 32-bit word of the accuracy double.
+
+- *Expert* mode:     (4, 0, **minbits**, **maxbits**, **maxprec**, **minexp**)
+
+  - **minbits**: Minimum number of compressed bits used to represent a block.
+  - **maxbits**: Maximum number of bits used to represent a block.
+  - **maxprec**: Maximum number of bit planes encoded.
+  - **minexp**: Smallest absolute bit plane number encoded.
+
+- *Reversible* mode: (5, 0, 0, 0, 0, 0)
+

--- a/hdf5plugin/__init__.py
+++ b/hdf5plugin/__init__.py
@@ -27,7 +27,7 @@ under windows, MacOS and linux."""
 
 __authors__ = ["V.A. Sole", "H. Payno", "T. Vincent"]
 __license__ = "MIT"
-__date__ = "24/04/2020"
+__date__ = "12/05/2020"
 
 import ctypes as _ctypes
 from glob import glob as _glob

--- a/hdf5plugin/__init__.py
+++ b/hdf5plugin/__init__.py
@@ -33,6 +33,7 @@ import ctypes as _ctypes
 from glob import glob as _glob
 import logging as _logging
 import os as _os
+import struct as _struct
 import sys as _sys
 if _sys.version_info[0] >= 3:
     from collections.abc import Mapping as _Mapping
@@ -197,8 +198,68 @@ class LZ4(_FilterRefClass):
 
 class Zfp(_FilterRefClass):
     """h5py.Group.create_dataset's compression and compression_opts arguments for using ZFP filter.
+
+    This filter provides different modes:
+
+    - **Fixed-rate** mode: To use, set the `rate` argument.
+       For details, see https://zfp.readthedocs.io/en/latest/modes.html#fixed-rate-mode.
+    - **Fixed-precision** mode: To use, set the `precision` argument.
+      For details, see https://zfp.readthedocs.io/en/latest/modes.html#fixed-precision-mode.
+    - **Fixed-accuracy** mode: To use, set the `accuracy` argument
+      For details, see https://zfp.readthedocs.io/en/latest/modes.html#fixed-accuracy-mode.
+    - **Reversible** (i.e., lossless) mode: To use, set the `reversible` argument to True
+      For details, see https://zfp.readthedocs.io/en/latest/modes.html#reversible-mode.
+    - **Expert** mode: To use, set the `minbits`, `maxbits`, `maxprec` and ``minexp` arguments.
+      For details, see https://zfp.readthedocs.io/en/latest/modes.html#expert-mode.
+
+    :param float rate:
+        Use fixed-rate mode and set the number of compressed bits per value.
+    :param float precision:
+        Use fixed-precision mode and set the number of uncompressed bits per value.
+    :param float accuracy:
+        Use fixed-accuracy mode and set the absolute error tolerance.
+    :param bool reversible:
+        If True, it uses the reversible (i.e., lossless) mode.
+    :param int minbits: Minimum number of compressed bits used to represent a block.
+    :param int maxbits: Maximum number of bits used to represent a block.
+    :param int maxprec: Maximum number of bit planes encoded.
+        It controls the relative error.
+    :param int minexp: Smallest absolute bit plane number encoded.
+        It controls the absolute error.
     """
     filter_id = ZFP_ID
+
+    def __init__(self,
+                 rate=None,
+                 precision=None,
+                 accuracy=None,
+                 reversible=False,
+                 minbits=None,
+                 maxbits=None,
+                 maxprec=None,
+                 minexp=None):
+        if rate is not None:
+            rateHigh, rateLow = _struct.unpack('II', _struct.pack('d', float(rate)))
+            self.filter_options = 1, 0, rateHigh, rateLow, 0, 0
+
+        elif precision is not None:
+            self.filter_options = 2, 0, int(precision), 0, 0, 0
+
+        elif accuracy is not None:
+            accuracyHigh, accuracyLow = _struct.unpack(
+                'II', _struct.pack('d', float(accuracy)))
+            self.filter_options = 3, 0, accuracyHigh, accuracyLow, 0, 0
+
+        elif reversible:
+            self.filter_options = 5, 0, 0, 0, 0, 0
+
+        elif minbits is not None:
+            minbits = int(minbits)
+            maxbits = int(maxbits)
+            maxprec = int(maxprec)
+            minexp = _struct.unpack('I', _struct.pack('i', int(minexp)))[0]
+            self.filter_options = 4, 0, minbits, maxbits, maxprec, minexp
+
 
 class FciDecomp(_FilterRefClass):
     """h5py.Group.create_dataset's compression and compression_opts arguments for using FciDecomp filter.

--- a/hdf5plugin/__init__.py
+++ b/hdf5plugin/__init__.py
@@ -268,7 +268,7 @@ class Zfp(_FilterRefClass):
         else:
            _logger.info("ZFP default used")
         
-        _logger.info("filter options = %s" % (self.filter_options))
+        _logger.info("filter options = %s" % (self.filter_options,))
 
 
 class FciDecomp(_FilterRefClass):

--- a/hdf5plugin/__init__.py
+++ b/hdf5plugin/__init__.py
@@ -241,17 +241,21 @@ class Zfp(_FilterRefClass):
         if rate is not None:
             rateHigh, rateLow = _struct.unpack('II', _struct.pack('d', float(rate)))
             self.filter_options = 1, 0, rateHigh, rateLow, 0, 0
+            _logger.info("ZFP mode 1 used. H5Z_ZFP_MODE_RATE")
 
         elif precision is not None:
             self.filter_options = 2, 0, int(precision), 0, 0, 0
+            _logger.info("ZFP mode 2 used. H5Z_ZFP_MODE_PRECISION")
 
         elif accuracy is not None:
             accuracyHigh, accuracyLow = _struct.unpack(
                 'II', _struct.pack('d', float(accuracy)))
             self.filter_options = 3, 0, accuracyHigh, accuracyLow, 0, 0
+            _logger.info("ZFP mode 3 used. H5Z_ZFP_MODE_ACCURACY")
 
         elif reversible:
             self.filter_options = 5, 0, 0, 0, 0, 0
+            _logger.info("ZFP mode 5 used. H5Z_ZFP_MODE_REVERSIBLE")
 
         elif minbits is not None:
             minbits = int(minbits)
@@ -259,6 +263,12 @@ class Zfp(_FilterRefClass):
             maxprec = int(maxprec)
             minexp = _struct.unpack('I', _struct.pack('i', int(minexp)))[0]
             self.filter_options = 4, 0, minbits, maxbits, maxprec, minexp
+            _logger.info("ZFP mode 4 used. H5Z_ZFP_MODE_EXPERT")
+        
+        else:
+           _logger.info("ZFP default used")
+        
+        _logger.info("filter options = %s" % (self.filter_options))
 
 
 class FciDecomp(_FilterRefClass):


### PR DESCRIPTION
This PR adds optional parameters to the `Zfp` filter in order to configure the compression mode.
It documents those modes in the README and add tests for it.