### PR TITLE
Add twine check test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ install:
     # Upgrade distribution modules
     - pip install --upgrade setuptools
     - python -m pip install --upgrade pip
+    - pip install --upgrade twine
 
     # Install build dependencies
     - pip install --upgrade wheel
@@ -50,6 +51,7 @@ install:
 
     # Generate source package or wheel
     - python setup.py $BUILD_COMMAND
+    - twine check dist/*
     - ls dist
 
 script:


### PR DESCRIPTION
This PR adds `twine check` to travis CI so as to detect possible issues with packaging for pypi.