### PR TITLE
Fixed support of wheel version>=0.35

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ except ImportError:
 else:
     from pkg_resources import parse_version
     import wheel
-    from wheel.pep425tags import get_platform
+    from wheel.bdist_wheel import get_platform
 
     class BDistWheel(bdist_wheel):
         """Override bdist_wheel to handle as pure python package"""


### PR DESCRIPTION
This PR fixes the build with latest version of the `wheel` package.
I also tested the fix with previous versions of `wheel`