### PR TITLE
Prepare v2.3.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+2.3.1
+-----
+
+- Fixed support of wheel package version >= 0.35 (PR #82)
+- Fixed typo in error log (PR #81)
+- Continuous integration: Added check of package description (PR #80)
+- Fixed handling of version info (PR #84)
+
 2.3
 ---
 

--- a/version.py
+++ b/version.py
@@ -62,9 +62,13 @@ __all__ = ["date", "version_info", "strictversion", "hexversion", "debianversion
 RELEASE_LEVEL_VALUE = {"dev": 0,
                        "alpha": 10,
                        "beta": 11,
-                       "gamma": 12,
-                       "rc": 13,
+                       "candidate": 12,
                        "final": 15}
+
+PRERELEASE_NORMALIZED_NAME = {"dev": "a",
+                              "alpha": "a",
+                              "beta": "b",
+                              "candidate": "rc"}
 
 MAJOR = 2
 MINOR = 3
@@ -83,10 +87,7 @@ strictversion = version = debianversion = "%d.%d.%d" % version_info[:3]
 if version_info.releaselevel != "final":
     version += "-%s%s" % version_info[-2:]
     debianversion += "~adev%i" % version_info[-1] if RELEV == "dev" else "~%s%i" % version_info[-2:]
-    prerel = "a" if RELEASE_LEVEL_VALUE.get(version_info[3], 0) < 10 else "b"
-    if prerel not in "ab":
-        prerel = "a"
-    strictversion += prerel + str(version_info[-1])
+    strictversion += PRERELEASE_NORMALIZED_NAME[version_info[3]] + str(version_info[-1])
 
 
 def calc_hexversion(major=0, minor=0, micro=0, releaselevel="dev", serial=0):

--- a/version.py
+++ b/version.py
@@ -73,7 +73,7 @@ PRERELEASE_NORMALIZED_NAME = {"dev": "a",
 MAJOR = 2
 MINOR = 3
 MICRO = 1
-RELEV = "dev"  # <16
+RELEV = "final"  # <16
 SERIAL = 0  # <16
 
 date = __date__


### PR DESCRIPTION
This PR synchronizes the `version.py` file with that of silx and prepare for a 2.3.1 bug fix release.