### PR TITLE
enable SIMD on power9 (requires gcc>=8)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,8 @@ def get_cpu_sse2_avx2():
     :returns: (is SSE2 available, is AVX2 available)
     :rtype: List(bool)
     """
+    if platform.machine() == "ppc64le":
+        return True, False
     try:
         import cpuinfo
     except ImportError as e:
@@ -345,6 +347,8 @@ bithsuffle_dir = 'src/bitshuffle'
 # Set compile args for both MSVC and others, list is stripped at build time
 extra_compile_args = ['-O3', '-ffast-math', '-std=c99', '-fopenmp']
 extra_compile_args += ['/Ox', '/fp:fast', '/openmp']
+if platform.machine() == "ppc64le":
+    extra_compile_args += ["-DNO_WARN_X86_INTRINSICS"]
 extra_link_args = ['-fopenmp', '/openmp']
 
 bithsuffle_plugin = HDF5PluginExtension(

--- a/src/bitshuffle/setup.py
+++ b/src/bitshuffle/setup.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function
 import glob
 import os
 from os import path
+import platform
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext as build_ext_
 from setuptools.command.develop import develop as develop_
@@ -25,8 +26,10 @@ VERSION = "%d.%d.%d" % (VERSION_MAJOR, VERSION_MINOR, VERSION_POINT)
 if VERSION_DEV:
     VERSION = VERSION + ".dev%d" % VERSION_DEV
 
-
-COMPILE_FLAGS = ['-O3', '-ffast-math', '-march=native', '-std=c99']
+if platform.machine() == "ppc64le":
+    COMPILE_FLAGS = ['-O3', '-ffast-math', '-mcpu=native', '-std=c99', "-DNO_WARN_X86_INTRINSICS"]
+else:
+    COMPILE_FLAGS= ['-O3', '-ffast-math', '-march=native', '-std=c99']
 # Cython breaks strict aliasing rules.
 COMPILE_FLAGS += ['-fno-strict-aliasing']
 COMPILE_FLAGS += ['-fPIC']

--- a/src/bitshuffle/src/bitshuffle_core.c
+++ b/src/bitshuffle/src/bitshuffle_core.c
@@ -20,7 +20,7 @@
 #define USEAVX2
 #endif
 
-#if defined(__SSE2__)
+#if defined(__SSE2__) || defined(NO_WARN_X86_INTRINSICS)
 #define USESSE2
 #endif
 


### PR DESCRIPTION
This speeds up the reading of Eiger2 dataset from 36ms to 19ms (on one core) on our power9 computers.
x86 computers are much faster for this task (~12ms)