### PR TITLE
Prepare 2.3.2b0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+2.3.2b0
+-------
+
+- Enabled SIMD on power9 for bitshuffle filter (PR #90)
+- Added debian/ubuntu packaging support (PR #87)
+- Updated CHANGELOG and version (PR #91)
+
 2.3.1
 -----
 

--- a/version.py
+++ b/version.py
@@ -73,7 +73,7 @@ PRERELEASE_NORMALIZED_NAME = {"dev": "a",
 MAJOR = 2
 MINOR = 3
 MICRO = 2
-RELEV = "dev"  # <16
+RELEV = "beta"  # <16
 SERIAL = 0  # <16
 
 date = __date__


### PR DESCRIPTION
This PR prepares a beta version in order to have a tag to make a ubuntu package for power9 with bitshuffle filter optimization. 