### PR TITLE
Avoid numpy 1.20 deprecation warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@
 - Enabled SIMD on power9 for bitshuffle filter (PR #90)
 - Added debian/ubuntu packaging support (PR #87)
 - Updated CHANGELOG and version (PR #91)
+- Fixed `numpy` 1.20 deprecation warning (PR #97)
 
 2.3.1
 -----

--- a/test/test.py
+++ b/test/test.py
@@ -56,7 +56,7 @@ class TestHDF5PluginRead(unittest.TestCase):
         self.assertTrue(data.shape[2] == 100, "Incorrect shape")
 
         target = numpy.arange(numpy.prod(expected_shape),
-                              dtype=numpy.float)
+                              dtype=numpy.float64)
         target.shape = expected_shape
         self.assertTrue(numpy.allclose(data, target), "Incorrect readout")
 


### PR DESCRIPTION
Minor PR to avoid `numpy` v1.20rc1 deprecation warning in tests.