### PR TITLE
Added ARM64 support; Added build config with environment variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,3 +104,15 @@ jobs:
           pip install --upgrade h5py==${{ matrix.H5PY_OLDER_VERSION }}
           pip list
           python test/test.py
+
+  build_wheels_macos:
+    name: Build wheels on macos-10.15
+    runs-on: macos-10.15
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build wheels
+        uses: joerick/cibuildwheel@v1.11.0
+        env:
+          CIBW_BUILD: cp39-macosx_*
+          CIBW_ARCHS_MACOS: x86_64 arm64 universal2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,3 +117,6 @@ jobs:
           CIBW_BUILD: cp39-macosx_*
           CIBW_ARCHS_MACOS: x86_64 arm64 universal2
           CIBW_BEFORE_BUILD: python -c "import platform;print('Machine:', platform.machine())"
+          HDF5PLUGIN_SSE2: False
+          HDF5PLUGIN_AVX2: False
+          HDF5PLUGIN_NATIVE: False

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,3 +116,4 @@ jobs:
         env:
           CIBW_BUILD: cp39-macosx_*
           CIBW_ARCHS_MACOS: x86_64 arm64 universal2
+          CIBW_BEFORE_BUILD: python -c "import platform;print('Machine:', platform.machine())"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           python test/test.py
 
   build_wheels_macos:
-    name: Build wheels on macos-10.15
+    name: Build ARM64 wheels on macos-10.15
     runs-on: macos-10.15
     steps:
       - uses: actions/checkout@v2
@@ -115,8 +115,7 @@ jobs:
         uses: joerick/cibuildwheel@v1.11.0
         env:
           CIBW_BUILD: cp39-macosx_*
-          CIBW_ARCHS_MACOS: x86_64 arm64 universal2
-          CIBW_BEFORE_BUILD: python -c "import platform;print('Machine:', platform.machine())"
+          CIBW_ARCHS_MACOS: arm64
           HDF5PLUGIN_SSE2: False
           HDF5PLUGIN_AVX2: False
           HDF5PLUGIN_NATIVE: False

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,8 @@ def get_cpu_sse2_avx2():
     :returns: (is SSE2 available, is AVX2 available)
     :rtype: List(bool)
     """
+    if platform.machine() == "arm64":
+        return False, False
     if platform.machine() == "ppc64le":
         return True, False
     try:
@@ -162,7 +164,9 @@ class Build(build):
                 logger.warning("C++11 disabled: not available")
 
         if self.sse2:
-            if (compiler.compiler_type == 'msvc' or
+            if platform.machine() == 'arm64':
+                self.sse2 = False
+            elif (compiler.compiler_type == 'msvc' or
                     platform.machine() == 'ppc64le'):
                 self.sse2 = True
             else:
@@ -171,7 +175,9 @@ class Build(build):
                 logger.warning("SSE2 disabled: not available")
 
         if self.avx2:
-            if compiler.compiler_type == 'msvc':
+            if platform.machine() == 'arm64':
+                self.avx2 = False
+            elif compiler.compiler_type == 'msvc':
                 self.avx2 = sys.version_info[:2] >= (3, 5)
             elif platform.machine() == 'ppc64le':
                 self.avx2 = False

--- a/setup.py
+++ b/setup.py
@@ -140,12 +140,15 @@ class Build(build):
 
     def initialize_options(self):
         build.initialize_options(self)
-        self.hdf5 = None
-        self.openmp = not sys.platform.startswith('darwin')
-        self.native = True
-        self.sse2 = True
-        self.avx2 = True
-        self.cpp11 = True
+        self.hdf5 = os.environ.get("HDF5PLUGIN_HDF5_DIR", None)
+        self.openmp = os.environ.get(
+            "HDF5PLUGIN_OPENMP",
+            "False" if sys.platform.startswith('darwin') else "True"
+        ) == "True"
+        self.native = os.environ.get("HDF5PLUGIN_NATIVE", "True") == "True"
+        self.sse2 = os.environ.get("HDF5PLUGIN_SSE2", "True") == "True"
+        self.avx2 = os.environ.get("HDF5PLUGIN_AVX2", "True") == "True"
+        self.cpp11 = os.environ.get("HDF5PLUGIN_CPP11", "True") == "True"
 
     def finalize_options(self):
         build.finalize_options(self)


### PR DESCRIPTION
This PR should add support for M1 by disabling SSE2 and AVX2 on `arm64` machines.
It also adds env var to configure default build options (useful with `cibuildwheel`)

~This is UNTESTED!~