### PR TITLE
Fixed debian/ubuntu packaging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ This version of `hdf5plugin` requires Python3 and supports arm64 architecture.
 - Fixed `FciDecomp` error message when built without c++11 (PR #113)
 - Updated blosc compile flags (`-std-c99`) to build for manylinux1 (PR #109)
 - Updated c-blosc to v1.20.1 (PR #101)
-- Updated: continuous integration (PR #104, #111), project structure (PR #114), changelog (PR #117)
+- Updated: continuous integration (PR #104, #111), project structure (PR #114, #118), changelog (PR #117)
 
 2.3.2
 -----

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,3 +12,4 @@ recursive-include doc *
 recursive-include src *
 recursive-include test *.py *.h5
 recursive-include package *
+global-exclude *__pycache__/*

--- a/build-deb.sh
+++ b/build-deb.sh
@@ -29,9 +29,6 @@
 
 project=hdf5plugin
 source_project=hdf5plugin
-version=$(python3 -c"import version; print(version.version)")
-strictversion=$(python3 -c"import version; print(version.strictversion)")
-debianversion=$(python3 -c"import version; print(version.debianversion)")
 
 deb_name=$(echo "$source_project" | tr '[:upper:]' '[:lower:]')
 
@@ -65,6 +62,13 @@ project_directory="`dirname \"$0\"`"
 project_directory="`( cd \"$project_directory\" && pwd )`" # absolutized
 dist_directory=${project_directory}/dist/${target_system}
 build_directory=${project_directory}/build/${target_system}
+
+# Get version info
+cd ${project_directory}/src/${project}
+version=$(python3 -B -c"import _version; print(_version.version)")
+strictversion=$(python3 -B -c"import _version; print(_version.strictversion)")
+debianversion=$(python3 -B -c"import _version; print(_version.debianversion)")
+cd ${project_directory}
 
 if [ -d /usr/lib/ccache ];
 then

--- a/setup.py
+++ b/setup.py
@@ -612,20 +612,14 @@ extensions = [lz4_plugin,
 
 # setup
 
-# ########## #
-# version.py #
-# ########## #
-
-def get_version():
-    """Returns current version number from version.py file"""
+def get_version(debian=False):
+    """Returns current version number from _version.py file"""
     dirname = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)),
-        'src',
-        'hdf5plugin')
+        os.path.dirname(os.path.abspath(__file__)), "src", PROJECT)
     sys.path.insert(0, dirname)
     import _version
     sys.path = sys.path[1:]
-    return _version.strictversion
+    return _version.debianversion if debian else _version.strictversion
 
 
 ################################################################################
@@ -646,8 +640,7 @@ class sdist_debian(sdist):
 
     @staticmethod
     def get_debian_name():
-        import version
-        name = "%s_%s" % (PROJECT, version.debianversion)
+        name = "%s_%s" % (PROJECT, get_version(debian=True))
         return name
 
     def prune_file_list(self):

--- a/setup.py
+++ b/setup.py
@@ -618,7 +618,7 @@ def get_version(debian=False):
         os.path.dirname(os.path.abspath(__file__)), "src", PROJECT)
     sys.path.insert(0, dirname)
     dont_write_bytecode = sys.dont_write_bytecode
-    #sys.dont_write_bytecode = True  # Avoid creating __pycache__/_version.pyc
+    sys.dont_write_bytecode = True  # Avoid creating __pycache__/_version.pyc
     import _version
     sys.path = sys.path[1:]
     sys.dont_write_bytecode = dont_write_bytecode

--- a/setup.py
+++ b/setup.py
@@ -617,8 +617,11 @@ def get_version(debian=False):
     dirname = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "src", PROJECT)
     sys.path.insert(0, dirname)
+    dont_write_bytecode = sys.dont_write_bytecode
+    #sys.dont_write_bytecode = True  # Avoid creating __pycache__/_version.pyc
     import _version
     sys.path = sys.path[1:]
+    sys.dont_write_bytecode = dont_write_bytecode
     return _version.debianversion if debian else _version.strictversion
 
 

--- a/setup.py
+++ b/setup.py
@@ -689,6 +689,7 @@ class sdist_debian(sdist):
 
 PROJECT = 'hdf5plugin'
 author = "ESRF - Data Analysis Unit"
+author_email = "silx@esrf.fr"
 description = "HDF5 Plugins for windows,MacOS and linux"
 url='https://github.com/silx-kit/hdf5plugin'
 f = open("README.rst")
@@ -726,6 +727,7 @@ if __name__ == "__main__":
     setup(name=PROJECT,
           version=get_version(),
           author=author,
+          author_email=author_email,
           url=url,
           classifiers=classifiers,
           description=description,


### PR DESCRIPTION
Fix `sdist_debian` broken following move of `version.py` (PR #114):
Updated `get_version()`,  `sdist_debian.get_debian_name` and `build-deb.sh` from silx (+ using `python -B`).

Also added `author_email` to remove a warning: "author_email needed when author is set"