### PR TITLE
Express Python version as an install requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -742,6 +742,7 @@ if __name__ == "__main__":
           author=author,
           author_email=author_email,
           url=url,
+          python_requires='>=3.4',
           classifiers=classifiers,
           description=description,
           long_description=long_description,


### PR DESCRIPTION
Users who do not pin their version to a specific version installing from Python 2 will get an error when trying to install the library, rather than being directed to install an earlier version automatically by the package index.
