### PR TITLE
Improved tests: Skips blosc with snappy tests when C++11 is disabled

### DIFF
--- a/src/hdf5plugin/test.py
+++ b/src/hdf5plugin/test.py
@@ -126,6 +126,8 @@ class TestHDF5PluginRW(unittest.TestCase):
                     with self.subTest(compression=cname,
                                       shuffle=shuffle,
                                       clevel=clevel):
+                        if cname == 'snappy' and not hdf5plugin.config.cpp11:
+                            self.skipTest("snappy unavailable without C++11")
                         filter_ = self._test(
                             'blosc',
                             compressed=clevel!=0,  # No compression for clevel=0


### PR DESCRIPTION
This avoids tests to fail when `hdf5plugin`is built without C++11 support and `snappy` is not available.