### PR TITLE
Create requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+setuptools


### PR DESCRIPTION
Until Python 3.10, setuptools is not the default build tool !