### PR TITLE
Fixed compilation issue occuring on ppc64le in conda-forge

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "src/snappy/third_party/benchmark"]
+	path = src/snappy/third_party/benchmark
+	url = https://github.com/google/benchmark.git
+[submodule "src/snappy/third_party/googletest"]
+	path = src/snappy/third_party/googletest
+	url = https://github.com/google/googletest.git

--- a/setup.py
+++ b/setup.py
@@ -617,6 +617,8 @@ include_dirs += glob(blosc_dir + 'internal-complibs/zstd*/common')
 define_macros.append(('HAVE_ZSTD', 1))
 
 extra_compile_args = ['-std=gnu99']  # Needed to build manylinux1 wheels
+extra_compile_args += ['-pthread']
+extra_link_args = ['-pthread']
 
 blosc_plugin = HDF5PluginExtension(
     "hdf5plugin.plugins.libh5blosc",
@@ -627,6 +629,7 @@ blosc_plugin = HDF5PluginExtension(
     include_dirs=include_dirs + [hdf5_blosc_dir],
     define_macros=define_macros,
     extra_compile_args=extra_compile_args,
+    extra_link_args=extra_link_args,
     sse2=sse2_kwargs,
     avx2=avx2_kwargs,
     cpp11=cpp11_kwargs,


### PR DESCRIPTION
This PR aims at fixing the test failure on conda-forge python3.9/ppc64le (see #153).
`blosc` is using `pthread`, but this was not explicitly set as compile and link argument.

It also adds a `.gitmodules` file for snappy submodules since conda-forge runs `git submodule update --init --recurse` as part of its build process.

Similar issue of scipy (https://github.com/scipy/scipy/issues/11323) with similar solution (https://github.com/scipy/scipy/pull/11324).