### PR TITLE
Added `-v` option to `python -m hdf5plugin.test`

### DIFF
--- a/src/hdf5plugin/test.py
+++ b/src/hdf5plugin/test.py
@@ -220,5 +220,9 @@ def run_tests(*args, **kwargs):
 
 
 if __name__ == '__main__':
+    import argparse
     import sys
-    sys.exit(0 if run_tests() else 1)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--verbose", "-v", action="count", default=1, help="Increase verbosity")
+    options = parser.parse_args()
+    sys.exit(0 if run_tests(verbosity=options.verbose) else 1)


### PR DESCRIPTION
This PR adds a verbosity option to the tests.
This is convenient to investigate broken tests.