### PR TITLE
Added pyproject.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Install from source package
         run:
-          pip install --pre --find-links dist/ --no-cache-dir --no-index hdf5plugin
+          pip install --pre dist/hdf5plugin*
 
       - name: Print python info
         run: |

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -24,43 +24,36 @@ To install from source and recompile the HDF5 plugins, run::
 
     pip install hdf5plugin --no-binary hdf5plugin [--user]
 
-To override the defaults that are probed from the machine, it is possible to specify build options.
-This is achieved by either setting environment variables or passing options to ``python setup.py build``, for example:
+To override the defaults that are probed from the machine,
+it is possible to specify build options by setting environment variables, for example:
 
 - ``HDF5PLUGIN_OPENMP=False pip install hdf5plugin --no-binary hdf5plugin``
-- From the source directory: ``python setup.py build --openmp=False``
+- From the source directory: ``HDF5PLUGIN_OPENMP=False pip install .``
 
 Available options
 .................
 
 .. list-table::
-   :widths: 1 1 4
+   :widths: 1 4
    :header-rows: 1
 
    * - Environment variable
-     - ``python setup.py build`` option
      - Description
    * - ``HDF5PLUGIN_HDF5_DIR``
-     - ``--hdf5``
      - Custom path to HDF5 (as in h5py).
    * - ``HDF5PLUGIN_OPENMP``
-     - ``--openmp``
      - Whether or not to compile with `OpenMP`_.
        Default: True if probed (always False on macOS).
    * - ``HDF5PLUGIN_NATIVE``
-     - ``--native``
      - True to compile specifically for the host, False for generic support (For unix compilers only).
        Default: True on supported architectures, False otherwise
    * - ``HDF5PLUGIN_SSE2``
-     - ``--sse2``
      - Whether or not to compile with `SSE2`_ support.
        Default: True on ppc64le and when probed on x86, False otherwise
    * - ``HDF5PLUGIN_AVX2``
-     - ``--avx2``
      - Whether or not to compile with `AVX2`_ support. avx2=True requires sse2=True.
        Default: True on x86 when probed, False otherwise
    * - ``HDF5PLUGIN_CPP11``
-     - ``--cpp11``
      - Whether or not to compile C++11 code if available.
        Default: True if probed.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["py-cpuinfo==8.0.0", "setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
+py-cpuinfo==8.0.0
 setuptools
 sphinx
 sphinx_rtd_theme
 nbsphinx
+wheel

--- a/setup.py
+++ b/setup.py
@@ -302,25 +302,12 @@ class Build(build):
     """Build command with extra options used by PluginBuildExt"""
 
     user_options = [
-        ('hdf5=', None, "Custom path to HDF5 (as in h5py). "
-         "Default: HDF5PLUGIN_HDF5_DIR environment variable if set."),
-        ('openmp=', None, "Whether or not to compile with OpenMP. "
-         "Default: HDF5PLUGIN_OPENMP env. var. if set, else "
-         "True if probed (always False on macOS)."),
-        ('native=', None, "True to compile specifically for the host, "
-         "False for generic support (For unix compilers only). "
-         "Default: HDF5PLUGIN_NATIVE env. var. if set, else "
-         "True on supported architectures, False otherwise"),
-        ('sse2=', None, "Whether or not to compile with SSE2 support. "
-         "Default: HDF5PLUGIN_SSE2 env. var. if set, else "
-         "True on ppc64le and when probed on x86, False otherwise"),
-        ('avx2=', None, "Whether or not to compile with AVX2 support. "
-         "avx2=True requires sse2=True. "
-         "Default: HDF5PLUGIN_AVX2 env. var. if set, else "
-         "True on x86 when probed, False otherwise"),
-        ('cpp11=', None, "Whether or not to compile C++11 code if available."
-         "Default: HDF5PLUGIN_CPP11 env. var. if set, else "
-         "True if probed."),
+        ('hdf5=', None, "Deprecated, use HDF5PLUGIN_HDF5_DIR environment variable"),
+        ('openmp=', None, "Deprecated, use HDF5PLUGIN_OPENMP environment variable"),
+        ('native=', None, "Deprecated, use HDF5PLUGIN_NATIVE environment variable"),
+        ('sse2=', None, "Deprecated, use HDF5PLUGIN_SSE2 environment variable"),
+        ('avx2=', None, "Deprecated, use HDF5PLUGIN_AVX2 environment variable"),
+        ('cpp11=', None, "Deprecated, use HDF5PLUGIN_CPP11 environment variable"),
         ]
     user_options.extend(build.user_options)
 
@@ -337,6 +324,13 @@ class Build(build):
 
     def finalize_options(self):
         build.finalize_options(self)
+        for argument in ('hdf5', 'cpp11', 'openmp', 'native', 'sse2', 'avx2'):
+            if getattr(self, argument) is not None:
+                logger.warning(
+                    "--%s Deprecation warning: "
+                    "use HDF5PLUGIN_%s environement variable.",
+                    argument,
+                    "HDF5_DIR" if argument == "hdf5" else argument.upper())
         self.hdf5plugin_config = BuildConfig(
             config_file=os.path.join(self.build_lib, PROJECT, '_config.py'),
             compiler=self.compiler,

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,13 @@ except Exception:  # cpuinfo raises Exception for unsupported architectures
     logger.warning("Architecture is not supported by cpuinfo")
     cpuinfo = None
 
+try:  # Embedded copy of cpuinfo
+    from cpuinfo import _parse_arch as cpuinfo_parse_arch
+except Exception:
+    try:  # Installed version of cpuinfo (when installing with pip)
+        from cpuinfo.cpuinfo import _parse_arch as cpuinfo_parse_arch
+    except Exception:
+        cpuinfo_parse_arch = None
 
 # Patch bdist_wheel
 try:
@@ -124,8 +131,8 @@ class HostConfig:
 
         # Get machine architecture description
         self.machine = platform.machine().lower()
-        if cpuinfo is not None:
-            self.arch = cpuinfo._parse_arch(self.machine)[0]
+        if cpuinfo_parse_arch is not None:
+            self.arch = cpuinfo_parse_arch(self.machine)[0]
         else:
             self.arch = None
 


### PR DESCRIPTION
This PR adds the missing `pyproject.toml` file to the project.
It also deprecates build options passed through the command line since calling `setup.py` directly is now deprecated.

closes #131