### PR TITLE
Clean-up `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -680,7 +680,6 @@ zstandard_plugin = HDF5PluginExtension(
     sources=zstandard_sources,
     depends=zstandard_depends,
     include_dirs=zstandard_include_dirs,
-    define_macros=define_macros,
     )
 
 


### PR DESCRIPTION
This PR removes passing `define_macros` to Zstd filter since the pass argument is the `define_macros` from blosc.