### PR TITLE
Fixed LZ4 filter compilation with HDF5PLUGIN_HDF5_DIR

### DIFF
--- a/src/hdf5/include/H5public.h
+++ b/src/hdf5/include/H5public.h
@@ -338,14 +338,9 @@ H5_DLL herr_t H5get_libversion(unsigned *majnum, unsigned *minnum,
 H5_DLL herr_t H5check_version(unsigned majnum, unsigned minnum,
 			       unsigned relnum);
 H5_DLL herr_t H5is_library_threadsafe(hbool_t *is_ts);
-// Special case
-// H5_DLL herr_t H5free_memory(void *mem);
-// H5_DLL void *H5allocate_memory(size_t size, hbool_t clear);
+H5_DLL herr_t H5free_memory(void *mem);
+H5_DLL void *H5allocate_memory(size_t size, hbool_t clear);
 H5_DLL void *H5resize_memory(void *mem, size_t size);
-
-// Filters should use malloc/free
-#define H5free_memory(mem) free(mem)
-#define H5allocate_memory(size, clear) malloc(size)
 
 #ifdef __cplusplus
 }

--- a/src/hdf5_dl.c
+++ b/src/hdf5_dl.c
@@ -30,6 +30,8 @@
  * HDF5 library.
  */
 #include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
 #include <dlfcn.h>
 #include "hdf5.h"
 #include "H5PLextern.h"
@@ -265,6 +267,23 @@ int init_filter(const char* libname)
 herr_t H5open(void)
 {
 CALL(0, H5open)
+};
+
+herr_t H5free_memory(void *mem)
+{
+    /* Special case: Compression filter is not suppose to use this function */
+    free(mem);
+    return 0;
+};
+
+void * H5allocate_memory(size_t size, hbool_t clear)
+{
+    /* Special case: Compression filter is not suppose to use this function */
+    void * ptr = malloc(size);
+    if (clear) {
+        memset(ptr, 0, size);
+    }
+    return ptr;
 };
 
 /*H5E*/


### PR DESCRIPTION
PR #172 fixed the use of `H5[free|allocate]_memory` by patching the hdf5 headers... which obviously does not work with user provided headers.
This PR provides `H5[free|allocate]_memory` functions which calls directly `free`/`allocate`.

closes #177