### PR TITLE
Renamed `PLUGINS_PATH` constant to `PLUGIN_PATH` without `S`

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -9,7 +9,7 @@
 Available constants:
 
 * ``hdf5plugin.FILTERS``: A dictionary mapping provided filters to their ID
-* ``hdf5plugin.PLUGINS_PATH``: The directory where the provided filters library are stored.
+* ``hdf5plugin.PLUGIN_PATH``: The directory where the provided filters library are stored.
 
 Read compressed datasets
 ++++++++++++++++++++++++
@@ -98,13 +98,13 @@ Zstd
 Use HDF5 filters in other applications
 ++++++++++++++++++++++++++++++++++++++
 
-Non `h5py`_ or non-Python users can also benefit from the supplied HDF5 compression filters for reading compressed datasets by setting the ``HDF5_PLUGIN_PATH`` environment variable the value of ``hdf5plugin.PLUGINS_PATH``, which can be retrieved from the command line with::
+Non `h5py`_ or non-Python users can also benefit from the supplied HDF5 compression filters for reading compressed datasets by setting the ``HDF5_PLUGIN_PATH`` environment variable the value of ``hdf5plugin.PLUGIN_PATH``, which can be retrieved from the command line with::
 
-    python -c "import hdf5plugin; print(hdf5plugin.PLUGINS_PATH)"
+    python -c "import hdf5plugin; print(hdf5plugin.PLUGIN_PATH)"
 
 For instance::
 
-    export HDF5_PLUGIN_PATH=$(python -c "import hdf5plugin; print(hdf5plugin.PLUGINS_PATH)")
+    export HDF5_PLUGIN_PATH=$(python -c "import hdf5plugin; print(hdf5plugin.PLUGIN_PATH)")
 
 should allow MatLab or IDL users to read data compressed using the supported plugins.
 

--- a/src/hdf5plugin/__init__.py
+++ b/src/hdf5plugin/__init__.py
@@ -50,10 +50,11 @@ from ._version import version, version_info, hexversion, strictversion  # noqa
 from ._config import config
 config = _namedtuple('HDF5PluginBuildOptions', tuple(config.keys()))(**config)
 
-PLUGINS_PATH = _os.path.abspath(
+PLUGIN_PATH = _os.path.abspath(
         _os.path.join(_os.path.dirname(__file__), 'plugins'))
 """Path where HDF5 filter plugins are stored"""
 
+PLUGINS_PATH = PLUGIN_PATH  # Backward compatibility
 
 # IDs of provided filters
 BLOSC_ID = 32001
@@ -431,7 +432,7 @@ def _init_filters():
 
         # Load DLL
         filename = _glob(_os.path.join(
-            PLUGINS_PATH, 'libh5' + name + '*' + config.filter_file_extension))
+            PLUGIN_PATH, 'libh5' + name + '*' + config.filter_file_extension))
         if len(filename):
             filename = filename[0]
         else:


### PR DESCRIPTION
This makes it inline with `HDF5_PLUGIN_PATH` env. var. name.

closes #175