### PR TITLE
Added optimisation flags for blosc filter compilation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -651,6 +651,8 @@ include_dirs += glob(blosc_dir + 'internal-complibs/zstd*/common')
 define_macros.append(('HAVE_ZSTD', 1))
 
 extra_compile_args = ['-std=gnu99']  # Needed to build manylinux1 wheels
+extra_compile_args += ['-O3', '-ffast-math']
+extra_compile_args += ['/Ox', '/fp:fast']
 extra_compile_args += ['-pthread']
 extra_link_args = ['-pthread']
 


### PR DESCRIPTION
This PR adds `-O3` and `-ffast-math` to blosc filter compilation.

From what I tested it seems to improve blosc+bitshuffle+lz4 performance... but not sure of other side effects...