### PR TITLE
Added `get_config()` function to retrieve information

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -6,11 +6,6 @@
 
 ``hdf5plugin`` allows using additional HDF5 compression filters with `h5py`_ for reading and writing compressed datasets.
 
-Available constants:
-
-* ``hdf5plugin.FILTERS``: A dictionary mapping provided filters to their ID
-* ``hdf5plugin.PLUGIN_PATH``: The directory where the provided filters library are stored.
-
 Read compressed datasets
 ++++++++++++++++++++++++
 
@@ -101,6 +96,21 @@ Zstd
 .. autoclass:: Zstd
    :members:
    :undoc-members:
+
+Get information about hdf5plugin
+++++++++++++++++++++++++++++++++
+
+Available constants:
+
+.. autodata:: FILTERS
+   :annotation:
+
+.. autodata:: PLUGIN_PATH
+   :annotation:
+
+Functions:
+
+.. autofunction:: get_config
 
 Use HDF5 filters in other applications
 ++++++++++++++++++++++++++++++++++++++

--- a/src/hdf5plugin/__init__.py
+++ b/src/hdf5plugin/__init__.py
@@ -450,6 +450,7 @@ def _init_filters():
         # Skip filters that were not embedded
         if name not in config.embedded_filters:
             _logger.debug("%s filter not available in this build of hdf5plugin.", name)
+            yield name, ("unknown", "unknown")
             continue
 
         # Check if filter is already loaded (not on buggy HDF5 versions)

--- a/src/hdf5plugin/__init__.py
+++ b/src/hdf5plugin/__init__.py
@@ -52,7 +52,7 @@ config = _namedtuple('HDF5PluginBuildConfig', tuple(config.keys()))(**config)
 
 PLUGIN_PATH = _os.path.abspath(
         _os.path.join(_os.path.dirname(__file__), 'plugins'))
-"""Path where HDF5 filter plugins are stored"""
+"""Directory where the provided HDF5 filter plugins are stored."""
 
 PLUGINS_PATH = PLUGIN_PATH  # Backward compatibility
 
@@ -86,7 +86,7 @@ FILTERS = {'blosc': BLOSC_ID,
            'zstd': ZSTD_ID,
            'fcidecomp': FCIDECOMP_ID,
            }
-"""Mapping of filter name to HDF5 filter ID for available filters"""
+"""Mapping of provided filter's name to their HDF5 filter ID."""
 
 
 try:
@@ -495,7 +495,7 @@ _filters = dict(_init_filters())  # Store loaded filters
 
 
 def get_config():
-    """Provides information about build configuration and filters registered by hdf5plugin
+    """Provides information about build configuration and filters registered by hdf5plugin.
     """
     registered_filters = dict((name, filename) for name, (filename, lib) in _filters.items())
     HDF5PluginConfig = _namedtuple(

--- a/src/hdf5plugin/__init__.py
+++ b/src/hdf5plugin/__init__.py
@@ -487,6 +487,7 @@ def _init_filters():
             _logger.error("Cannot initialize filter %s: %d", name, retval)
             continue
 
+        _logger.debug("Registered filter: %s (%s)", name, filename)
         yield filename, lib
 
 

--- a/src/hdf5plugin/__init__.py
+++ b/src/hdf5plugin/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -450,13 +450,13 @@ def _init_filters():
         # Skip filters that were not embedded
         if name not in config.embedded_filters:
             _logger.debug("%s filter not available in this build of hdf5plugin.", name)
-            yield name, ("unknown", "unknown")
             continue
 
         # Check if filter is already loaded (not on buggy HDF5 versions)
         if (1, 8, 20) <= hdf5_version < (1, 10) or hdf5_version >= (1, 10, 2):
             if _h5py.h5z.filter_avail(filter_id):
                 _logger.info("%s filter already loaded, skip it.", name)
+                yield name, ("unknown", "unknown")
                 continue
 
         # Load DLL

--- a/src/hdf5plugin/__init__.py
+++ b/src/hdf5plugin/__init__.py
@@ -48,7 +48,7 @@ from ._version import version, version_info, hexversion, strictversion  # noqa
 
 # Give access to build-time config
 from ._config import config
-config = _namedtuple('HDF5PluginBuildOptions', tuple(config.keys()))(**config)
+config = _namedtuple('HDF5PluginBuildConfig', tuple(config.keys()))(**config)
 
 PLUGIN_PATH = _os.path.abspath(
         _os.path.join(_os.path.dirname(__file__), 'plugins'))
@@ -488,7 +488,21 @@ def _init_filters():
             continue
 
         _logger.debug("Registered filter: %s (%s)", name, filename)
-        yield filename, lib
+        yield name, (filename, lib)
 
 
 _filters = dict(_init_filters())  # Store loaded filters
+
+
+def get_config():
+    """Provides information about build configuration and filters registered by hdf5plugin
+    """
+    registered_filters = dict((name, filename) for name, (filename, lib) in _filters.items())
+    HDF5PluginConfig = _namedtuple(
+        'HDF5PluginConfig',
+        ('build_config', 'registered_filters'),
+    )
+    return HDF5PluginConfig(
+        build_config=config,
+        registered_filters=dict((name, filename) for name, (filename, lib) in _filters.items()),
+    )


### PR DESCRIPTION
This PR:
- adds a debug log when successfully registering a filter.
- adds and document a `get_config()` function with provides access to both build-time options and runtime registered filters.

Previously `hdf5plugin.config` was available (and still is) to provide build time config but it is not documented.

I hesitated between providing a dedicated `get_registered_filters()` function and providing a more general `get_config()` one as this PR proposes. I chose the later to avoid having too many functions for accessing debug/more advanced information. Any other opinion? Better naming?

closes #185