### PR TITLE
Updated documentation; Added Zenodo DOI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 hdf5plugin
 ==========
 
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.7257761.svg
+   :target: https://doi.org/10.5281/zenodo.7257761
+
 *hdf5plugin* provides `HDF5 compression filters <https://portal.hdfgroup.org/display/support/Registered+Filter+Plugins>`_` (namely: blosc, bitshuffle, bzip2, FCIDECOMP, lz4, ZFP, zstd) and makes them usable from `h5py <https://www.h5py.org>`_.
 
 See `documentation <http://www.silx.org/doc/hdf5plugin/latest/>`_.

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 hdf5plugin
 ==========
 
-*hdf5plugin* provides HDF5 compression filters (namely: blosc, bitshuffle, bzip2, FCIDECOMP, lz4, ZFP, zstd) and makes them usable from `h5py <https://www.h5py.org>`_.
+*hdf5plugin* provides `HDF5 compression filters <https://portal.hdfgroup.org/display/support/Registered+Filter+Plugins>`_` (namely: blosc, bitshuffle, bzip2, FCIDECOMP, lz4, ZFP, zstd) and makes them usable from `h5py <https://www.h5py.org>`_.
 
 See `documentation <http://www.silx.org/doc/hdf5plugin/latest/>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 hdf5plugin
 ==========
 
-*hdf5plugin* provides HDF5 compression filters (namely: blosc, bitshuffle, lz4, FCIDECOMP, ZFP, zstd) and makes them usable from `h5py <https://www.h5py.org>`_.
+*hdf5plugin* provides HDF5 compression filters (namely: blosc, bitshuffle, bzip2, FCIDECOMP, lz4, ZFP, zstd) and makes them usable from `h5py <https://www.h5py.org>`_.
 
 See `documentation <http://www.silx.org/doc/hdf5plugin/latest/>`_.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,7 +1,7 @@
 hdf5plugin
 ==========
 
-*hdf5plugin* provides HDF5 compression filters (namely: blosc, bitshuffle, lz4, FCIDECOMP, ZFP, zstd) and makes them usable from `h5py <https://www.h5py.org>`_.
+*hdf5plugin* provides HDF5 compression filters (namely: blosc, bitshuffle, bzip2, FCIDECOMP, lz4, ZFP, zstd) and makes them usable from `h5py <https://www.h5py.org>`_.
 
 * Supported operating systems: Linux, Windows, macOS.
 * Supported versions of Python: >= 3.4

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,7 +1,7 @@
 hdf5plugin
 ==========
 
-*hdf5plugin* provides HDF5 compression filters (namely: blosc, bitshuffle, bzip2, FCIDECOMP, lz4, ZFP, zstd) and makes them usable from `h5py <https://www.h5py.org>`_.
+*hdf5plugin* provides `HDF5 compression filters <https://portal.hdfgroup.org/display/support/Registered+Filter+Plugins>`_ (namely: blosc, bitshuffle, bzip2, FCIDECOMP, lz4, ZFP, zstd) and makes them usable from `h5py <https://www.h5py.org>`_.
 
 * Supported operating systems: Linux, Windows, macOS.
 * Supported versions of Python: >= 3.4

--- a/doc/information.rst
+++ b/doc/information.rst
@@ -25,6 +25,11 @@ Project resources
   - Windows: `AppVeyor <https://ci.appveyor.com/project/ESRF/hdf5plugin>`_
 - `Weekly builds <https://silx.gitlab-pages.esrf.fr/bob/hdf5plugin/>`_
 
+`hdf5plugin` can be cited with its `Zenodo DOI <https://doi.org/10.5281/zenodo.7257761>`_.
+
+Presentations
+-------------
+
 * :doc:`Presentation <hdf5plugin_EuropeanHUG2022>` at the `European HDF Users Group (HUG) Meeting 2022 <https://www.hdfgroup.org/hug/europeanhug22/>`_:
 
   - :doc:`Presentation material <hdf5plugin_EuropeanHUG2022>`

--- a/package/debian10/control
+++ b/package/debian10/control
@@ -18,7 +18,7 @@ Description: HDF5 Plugins for windows,MacOS and linux
  hdf5plugin
  ==========
  .
- This module provides HDF5 compression filters (namely: blosc, bitshuffle, lz4, FCIDECOMP, ZFP) and registers them to the HDF5 library used by `h5py <https://www.h5py.org>`_.
+ This module provides HDF5 compression filters (namely: blosc, bitshuffle, bzip2,FCIDECOMP, lz4, ZFP, zstd) and registers them to the HDF5 library used by `h5py <https://www.h5py.org>`_.
  .
  * Supported operating systems: Linux, Windows, macOS.
  * Supported versions of Python: 2.7 and >= 3.4

--- a/package/debian10/control
+++ b/package/debian10/control
@@ -18,7 +18,7 @@ Description: HDF5 Plugins for windows,MacOS and linux
  hdf5plugin
  ==========
  .
- This module provides HDF5 compression filters (namely: blosc, bitshuffle, bzip2,FCIDECOMP, lz4, ZFP, zstd) and registers them to the HDF5 library used by `h5py <https://www.h5py.org>`_.
+ This module provides `HDF5 compression filters <https://portal.hdfgroup.org/display/support/Registered+Filter+Plugins>`_ (namely: blosc, bitshuffle, bzip2,FCIDECOMP, lz4, ZFP, zstd) and registers them to the HDF5 library used by `h5py <https://www.h5py.org>`_.
  .
  * Supported operating systems: Linux, Windows, macOS.
  * Supported versions of Python: 2.7 and >= 3.4

--- a/package/debian11/control
+++ b/package/debian11/control
@@ -18,7 +18,7 @@ Description: HDF5 Plugins for windows,MacOS and linux
  hdf5plugin
  ==========
  .
- This module provides HDF5 compression filters (namely: blosc, bitshuffle, lz4, FCIDECOMP, ZFP) and registers them to the HDF5 library used by `h5py <https://www.h5py.org>`_.
+ This module provides HDF5 compression filters (namely: blosc, bitshuffle, bzip2,FCIDECOMP, lz4, ZFP, zstd) and registers them to the HDF5 library used by `h5py <https://www.h5py.org>`_.
  .
  * Supported operating systems: Linux, Windows, macOS.
  * Supported versions of Python: 2.7 and >= 3.4

--- a/package/debian11/control
+++ b/package/debian11/control
@@ -18,7 +18,7 @@ Description: HDF5 Plugins for windows,MacOS and linux
  hdf5plugin
  ==========
  .
- This module provides HDF5 compression filters (namely: blosc, bitshuffle, bzip2,FCIDECOMP, lz4, ZFP, zstd) and registers them to the HDF5 library used by `h5py <https://www.h5py.org>`_.
+ This module provides `HDF5 compression filters <https://portal.hdfgroup.org/display/support/Registered+Filter+Plugins>`_ (namely: blosc, bitshuffle, bzip2,FCIDECOMP, lz4, ZFP, zstd) and registers them to the HDF5 library used by `h5py <https://www.h5py.org>`_.
  .
  * Supported operating systems: Linux, Windows, macOS.
  * Supported versions of Python: 2.7 and >= 3.4


### PR DESCRIPTION
This PR fixes the list of filters in the documentation: bzip2 and zstd were not advertised.

It also advertises the recently created Zenodo DOI: https://doi.org/10.5281/zenodo.7257761