### PR TITLE
Added `register` function

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -120,10 +120,10 @@ When imported, `hdf5plugin` initialises and registers the filters it embeds if t
 `h5py`_ gives access to HDF5 functions handling registered filters in `h5py.h5z`_.
 This module allows checking the filter availability and registering/unregistering filters.
 
-`hdf5plugin` provides an extra `register_filter` function to register the filters it provides, e.g., to override an already loaded filters.
+`hdf5plugin` provides an extra `register` function to register the filters it provides, e.g., to override an already loaded filters.
 Registering with this function is required to perform additional initialisation and enable writing compressed data with the given filter.
 
-.. autofunction:: register_filter
+.. autofunction:: register
 
 Use HDF5 filters in other applications
 ++++++++++++++++++++++++++++++++++++++

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -102,11 +102,13 @@ Get information about hdf5plugin
 
 Available constants:
 
-.. autodata:: FILTERS
-   :annotation:
+.. py:data:: FILTERS
 
-.. autodata:: PLUGIN_PATH
-   :annotation:
+   Mapping of provided filter's name to their HDF5 filter ID.
+
+.. py:data:: PLUGIN_PATH
+
+   Directory where the provided HDF5 filter plugins are stored.
 
 Functions:
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -112,6 +112,19 @@ Functions:
 
 .. autofunction:: get_config
 
+Manage registered filters
++++++++++++++++++++++++++
+
+When imported, `hdf5plugin` initialises and registers the filters it embeds if there is no already registered filters for the corresponding filter IDs.
+
+`h5py`_ gives access to HDF5 functions handling registered filters in `h5py.h5z`_.
+This module allows checking the filter availability and registering/unregistering filters.
+
+`hdf5plugin` provides an extra `register_filter` function to register the filters it provides, e.g., to override an already loaded filters.
+Registering with this function is required to perform additional initialisation and enable writing compressed data with the given filter.
+
+.. autofunction:: register_filter
+
 Use HDF5 filters in other applications
 ++++++++++++++++++++++++++++++++++++++
 
@@ -128,4 +141,5 @@ should allow MatLab or IDL users to read data compressed using the supported plu
 Setting the ``HDF5_PLUGIN_PATH`` environment variable allows already existing programs or Python code to read compressed data without any modification.
 
 .. _h5py: https://www.h5py.org
+.. _h5py.h5z: https://github.com/h5py/h5py/blob/master/h5py/h5z.pyx
 .. _h5py.Group.create_dataset: https://docs.h5py.org/en/stable/high/group.html#h5py.Group.create_dataset

--- a/src/hdf5plugin/__init__.py
+++ b/src/hdf5plugin/__init__.py
@@ -38,7 +38,7 @@ from ._filters import ZFP_ID, Zfp  # noqa
 from ._filters import ZSTD_ID, Zstd  # noqa
 from ._filters import SZ_ID, SZ  # noqa
 
-from ._utils import get_config, PLUGIN_PATH, register_filter  # noqa
+from ._utils import get_config, PLUGIN_PATH, register  # noqa
 
 # Backward compatibility
 from ._config import build_config as config  # noqa

--- a/src/hdf5plugin/__init__.py
+++ b/src/hdf5plugin/__init__.py
@@ -38,7 +38,7 @@ from ._filters import ZFP_ID, Zfp  # noqa
 from ._filters import ZSTD_ID, Zstd  # noqa
 from ._filters import SZ_ID, SZ  # noqa
 
-from ._utils import get_config, PLUGIN_PATH  # noqa
+from ._utils import get_config, PLUGIN_PATH, register_filter  # noqa
 
 # Backward compatibility
 from ._config import build_config as config  # noqa

--- a/src/hdf5plugin/_utils.py
+++ b/src/hdf5plugin/_utils.py
@@ -60,7 +60,7 @@ def is_filter_available(name):
     return h5py.h5z.filter_avail(filter_id) > 0
 
 
-REGISTERED_FILTERS = {}
+registered_filters = {}
 """Store hdf5plugin registered filters as a mapping: name: (filename, ctypes.CDLL)"""
 
 
@@ -94,7 +94,7 @@ def register_filter(name):
         except RuntimeError:
             logger.debug("Filter %s (%d) not unregistered" % (name, filter_id))
             logger.debug(traceback.format_exc())
-    REGISTERED_FILTERS.pop(name, None)
+    registered_filters.pop(name, None)
 
     # Load DLL
     filename = glob.glob(os.path.join(
@@ -127,7 +127,7 @@ def register_filter(name):
         return False
 
     logger.debug("Registered filter: %s (%s)", name, filename)
-    REGISTERED_FILTERS[name] = filename, lib
+    registered_filters[name] = filename, lib
     return True
 
 
@@ -140,16 +140,16 @@ HDF5PluginConfig = namedtuple(
 def get_config():
     """Provides information about build configuration and filters registered by hdf5plugin.
     """
-    registered_filters = {}
+    filters = {}
     for name in FILTERS:
-        info = REGISTERED_FILTERS.get(name)
+        info = registered_filters.get(name)
         if info is not None:  # Registered by hdf5plugin
             if is_filter_available(name) in (True, None):
-                registered_filters[name] = info[0]
+                filters[name] = info[0]
         elif is_filter_available(name) is True:  # Registered elsewhere
-            registered_filters[name] = "unknown"
+            filters[name] = "unknown"
 
-    return HDF5PluginConfig(build_config, registered_filters)
+    return HDF5PluginConfig(build_config, filters)
 
 
 def register(filters=tuple(FILTERS.keys()), force=True):
@@ -166,7 +166,7 @@ def register(filters=tuple(FILTERS.keys()), force=True):
     :rtype: bool
     """
     if isinstance(filters, str):
-        names = (filters,)
+        filters = (filters,)
 
     status = True
     for filter_name in filters:

--- a/src/hdf5plugin/_utils.py
+++ b/src/hdf5plugin/_utils.py
@@ -83,12 +83,15 @@ def register_filter(name):
     # Unregister existing filter
     filter_id = FILTERS[name]
     is_avail = is_filter_available(name)
-    # TODO h5py>=2.10
+    if h5py.version.version_tuple < (2, 10) and is_avail in (True, None):
+        logger.error(
+            "h5py.h5z.unregister_filter is not available in this version of h5py.")
+        return False
     if is_avail is True:
         if not h5py.h5z.unregister_filter(filter_id):
             logger.error("Failed to unregister filter %s (%d)" % (name, filter_id))
             return False
-    elif is_avail is None:  # Cannot probe filter availability
+    if is_avail is None:  # Cannot probe filter availability
         try:
             h5py.h5z.unregister_filter(filter_id)
         except RuntimeError:

--- a/src/hdf5plugin/_utils.py
+++ b/src/hdf5plugin/_utils.py
@@ -158,8 +158,6 @@ def get_config():
 def register(filters=tuple(FILTERS.keys()), force=True):
     """Initialise and register `hdf5plugin` embedded filters given their names.
 
-    Unregister corresponding previously registered filters if any.
-
     :param Union[str.Tuple[str]] filters:
         Filter name or sequence of filter names (See `hdf5plugin.FILTERS`).
     :param bool force:

--- a/src/hdf5plugin/test.py
+++ b/src/hdf5plugin/test.py
@@ -270,22 +270,32 @@ class TestPackage(unittest.TestCase):
 
 
 class TestRegisterFilter(BaseTestHDF5PluginRW):
-    """Test usage of the register_filter function"""
+    """Test usage of the register function"""
+
+    def _simple_test(self, filter_name):
+        if filter_name == 'fcidecomp':
+            self._test('fcidecomp', dtype=numpy.uint8)
+        elif filter_name in ('sz', 'zfp'):
+            self._test(filter_name, dtype=numpy.float32, lossless=False)
+        else:
+            self._test(filter_name)
 
     @unittest.skipUnless(hdf5plugin.config.embedded_filters, "No embedded filters")
-    def test(self):
-        """Re-register all embedded filters"""
+    def test_register_single_filter(self):
+        """Re-register embedded filters one at a time"""
         for name in hdf5plugin.config.embedded_filters:
             with self.subTest(name=name):
-                status = hdf5plugin.register_filter(name)
+                status = hdf5plugin.register(name, force=True)
                 self.assertTrue(status)
+                self._simple_test(name)
 
-                if name == 'fcidecomp':
-                    self._test('fcidecomp', dtype=numpy.uint8)
-                elif name in ('sz', 'zfp'):
-                    self._test(name, dtype=numpy.float32, lossless=False)
-                else:
-                    self._test(name)
+    @unittest.skipUnless(hdf5plugin.config.embedded_filters, "No embedded filters")
+    def test_register_all_filters(self):
+        """Re-register embedded filters all at once"""
+        status = hdf5plugin.register()
+        for name in hdf5plugin.config.embedded_filters:
+            with self.subTest(name=name):
+                self._simple_test(name)
 
 
 def suite():

--- a/src/hdf5plugin/test.py
+++ b/src/hdf5plugin/test.py
@@ -283,19 +283,19 @@ class TestRegisterFilter(BaseTestHDF5PluginRW):
     @unittest.skipUnless(hdf5plugin.config.embedded_filters, "No embedded filters")
     def test_register_single_filter(self):
         """Re-register embedded filters one at a time"""
-        for name in hdf5plugin.config.embedded_filters:
-            with self.subTest(name=name):
-                status = hdf5plugin.register(name, force=True)
+        for filter_name in hdf5plugin.config.embedded_filters:
+            with self.subTest(name=filter_name):
+                status = hdf5plugin.register(filter_name, force=True)
                 self.assertTrue(status)
-                self._simple_test(name)
+                self._simple_test(filter_name)
 
     @unittest.skipUnless(hdf5plugin.config.embedded_filters, "No embedded filters")
     def test_register_all_filters(self):
         """Re-register embedded filters all at once"""
         status = hdf5plugin.register()
-        for name in hdf5plugin.config.embedded_filters:
-            with self.subTest(name=name):
-                self._simple_test(name)
+        for filter_name in hdf5plugin.config.embedded_filters:
+            with self.subTest(name=filter_name):
+                self._simple_test(filter_name)
 
 
 def suite():

--- a/src/hdf5plugin/test.py
+++ b/src/hdf5plugin/test.py
@@ -280,6 +280,7 @@ class TestRegisterFilter(BaseTestHDF5PluginRW):
         else:
             self._test(filter_name)
 
+    @unittest.skipIf(h5py.version.version_tuple < (2, 10), "h5py<2.10: unregister_filer not available")
     @unittest.skipUnless(hdf5plugin.config.embedded_filters, "No embedded filters")
     def test_register_single_filter(self):
         """Re-register embedded filters one at a time"""
@@ -289,6 +290,7 @@ class TestRegisterFilter(BaseTestHDF5PluginRW):
                 self.assertTrue(status)
                 self._simple_test(filter_name)
 
+    @unittest.skipIf(h5py.version.version_tuple < (2, 10), "h5py<2.10: unregister_filer not available")
     @unittest.skipUnless(hdf5plugin.config.embedded_filters, "No embedded filters")
     def test_register_all_filters(self):
         """Re-register embedded filters all at once"""


### PR DESCRIPTION
This PR adds a `register(filters=FILTERS, force=True)` function to the API.
With this function it is possible to manually re-register filters embedded in `hdf5plugin`.

The main use case should be to make sure embedded filters are use, which is done with:
```python
import hdf5plugin
hdf5plugin.register()
```

Related to #204