### PR TITLE
Added `get_filters` function; Fixed `register`

### DIFF
--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -57,7 +57,7 @@ This briefly describes the steps to add a HDF5 compression filter to the zoo.
 
 * Add a compression options helper class named ``FilterName`` in ``hdf5plugins/_filters.py`` which should inherit from ``_FilterRefClass``.
   This is intended to ease the usage of ``h5py.Group.create_dataset`` ``compression_opts`` argument.
-  It must have a `_filter_name` class attribute with the same name as in the extension defined in ``setup.py`` (without the ``libh5`` prefix) .
+  It must have a `filter_name` class attribute with the same name as in the extension defined in ``setup.py`` (without the ``libh5`` prefix) .
   This name is used to find the filter library.
 
 * Add ``FilterName`` to ``hdf5plugin._filters.FILTER_CLASSES``.

--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -50,17 +50,17 @@ This briefly describes the steps to add a HDF5 compression filter to the zoo.
 * Update ``setup.py`` to build the filter dynamic library by adding an extension using the ``HDF5PluginExtension`` class (a subclass of ``setuptools.Extension``) which adds extra files and compile options to enable dynamic loading of the filter.
   The name of the extension should be ``hdf5plugin.plugins.libh5<filter_name>``.
 
+* In case of import errors related to HDF5-related undefined symbols, add eventual missing functions under ``src/hdf5_dl.c``.
+
 * Add a "CONSTANT" in ``src/hdf5plugin/_filters.py`` named with the ``FILTER_NAME_ID`` which value is the HDF5 filter ID
   (See `HDF5 registered filters <https://portal.hdfgroup.org/display/support/Registered+Filters>`_).
 
-* Add a ``"<filter_name>": <FILTER_ID_CONSTANT>`` entry in ``hdf5plugin._filters.FILTERS``.
-  You must use the same `filter_name` as in the extension in ``setup.py`` (without the ``libh5`` prefix) .
-  The names in ``FILTERS`` are used to find the available filter libraries.
-
-* In case of import errors related to HDF5-related undefined symbols, add eventual missing functions under ``src/hdf5_dl.c``.
-
 * Add a compression options helper class named ``FilterName`` in ``hdf5plugins/_filters.py`` which should inherit from ``_FilterRefClass``.
   This is intended to ease the usage of ``h5py.Group.create_dataset`` ``compression_opts`` argument.
+  It must have a `_filter_name` class attribute with the same name as in the extension defined in ``setup.py`` (without the ``libh5`` prefix) .
+  This name is used to find the filter library.
+
+* Add ``FilterName`` to ``hdf5plugin._filters.FILTER_CLASSES``.
 
 * Add to ``hdf5plugin/__init__.py`` the import of the filter ID and helper class:
   ``from ._filters import FILTER_NAME_ID, FilterName  # noqa``

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -100,17 +100,15 @@ Zstd
 Get information about hdf5plugin
 ++++++++++++++++++++++++++++++++
 
-Available constants:
-
-.. py:data:: FILTERS
-
-   Mapping of provided filter's name to their HDF5 filter ID.
+Constants:
 
 .. py:data:: PLUGIN_PATH
 
    Directory where the provided HDF5 filter plugins are stored.
 
 Functions:
+
+.. autofunction:: get_filters
 
 .. autofunction:: get_config
 

--- a/src/hdf5plugin/__init__.py
+++ b/src/hdf5plugin/__init__.py
@@ -40,7 +40,7 @@ from ._filters import ZFP_ID, Zfp  # noqa
 from ._filters import ZSTD_ID, Zstd  # noqa
 from ._filters import SZ_ID, SZ  # noqa
 
-from ._utils import get_config, PLUGIN_PATH, register  # noqa
+from ._utils import get_config, get_filters, PLUGIN_PATH, register  # noqa
 
 # Backward compatibility
 PLUGINS_PATH = PLUGIN_PATH

--- a/src/hdf5plugin/_filters.py
+++ b/src/hdf5plugin/_filters.py
@@ -59,17 +59,6 @@ SZ_ID = 32017
 FCIDECOMP_ID = 32018
 """FCIDECOMP filter ID"""
 
-FILTERS = {'blosc': BLOSC_ID,
-           'bshuf': BSHUF_ID,
-           'bzip2': BZIP2_ID,
-           'lz4': LZ4_ID,
-           'zfp': ZFP_ID,
-           'zstd': ZSTD_ID,
-           'sz': SZ_ID,
-           'fcidecomp': FCIDECOMP_ID,
-           }
-"""Mapping of provided filter's name to their HDF5 filter ID."""
-
 
 try:
     _FilterRefClass = h5py.filters.FilterRefBase
@@ -128,6 +117,7 @@ class Bitshuffle(_FilterRefClass):
         Can be negative, and must be below or equal to 22 (maximum compression).
         Default: 3.
     """
+    _filter_name = "bshuf"
     filter_id = BSHUF_ID
 
     __COMPRESSIONS = {
@@ -201,6 +191,7 @@ class Blosc(_FilterRefClass):
     BITSHUFFLE = 2
     """Flag to enable bit-wise shuffle pre-compression filter"""
 
+    _filter_name = "blosc"
     filter_id = BLOSC_ID
 
     __COMPRESSIONS = {
@@ -236,6 +227,7 @@ class BZip2(_FilterRefClass):
 
     :param int blocksize: Size of the blocks as a multiple of 100k
     """
+    _filter_name = "bzip2"
     filter_id = BZIP2_ID
 
     def __init__(self, blocksize=9) -> None:
@@ -258,6 +250,7 @@ class FciDecomp(_FilterRefClass):
             **hdf5plugin.FciDecomp())
         f.close()
     """
+    _filter_name = "fcidecomp"
     filter_id = FCIDECOMP_ID
 
     def __init__(self, *args, **kwargs):
@@ -285,6 +278,7 @@ class LZ4(_FilterRefClass):
         It needs to be in the range of 0 < nbytes < 2113929216 (1,9GB).
         Default: 0 (for 1GB per block).
     """
+    _filter_name = "lz4"
     filter_id = LZ4_ID
 
     def __init__(self, nbytes=0):
@@ -374,6 +368,7 @@ class Zfp(_FilterRefClass):
     :param int minexp: Smallest absolute bit plane number encoded.
         It controls the absolute error.
     """
+    _filter_name = "zfp"
     filter_id = ZFP_ID
 
     def __init__(self,
@@ -468,7 +463,7 @@ class SZ(_FilterRefClass):
               **hdf5plugin.SZ(pointwise_relative=0.01))
 
     """
-
+    _filter_name = "sz"
     filter_id = SZ_ID
 
     def __init__(self, absolute=None, relative=None, pointwise_relative=1e-05):
@@ -527,8 +522,16 @@ class Zstd(_FilterRefClass):
             **hdf5plugin.Zstd(clevel=22))
         f.close()
     """
+    _filter_name = "zstd"
     filter_id = ZSTD_ID
 
     def __init__(self, clevel=3):
         assert 1 <= clevel <= 22
         self.filter_options = (clevel,)
+
+
+FILTER_CLASSES = Bitshuffle, Blosc, BZip2, FciDecomp, LZ4, SZ, Zfp, Zstd
+
+
+FILTERS = dict((cls._filter_name, cls.filter_id) for cls in FILTER_CLASSES)
+"""Mapping of provided filter's name to their HDF5 filter ID."""

--- a/src/hdf5plugin/_filters.py
+++ b/src/hdf5plugin/_filters.py
@@ -117,7 +117,7 @@ class Bitshuffle(_FilterRefClass):
         Can be negative, and must be below or equal to 22 (maximum compression).
         Default: 3.
     """
-    _filter_name = "bshuf"
+    filter_name = "bshuf"
     filter_id = BSHUF_ID
 
     __COMPRESSIONS = {
@@ -191,7 +191,7 @@ class Blosc(_FilterRefClass):
     BITSHUFFLE = 2
     """Flag to enable bit-wise shuffle pre-compression filter"""
 
-    _filter_name = "blosc"
+    filter_name = "blosc"
     filter_id = BLOSC_ID
 
     __COMPRESSIONS = {
@@ -227,7 +227,7 @@ class BZip2(_FilterRefClass):
 
     :param int blocksize: Size of the blocks as a multiple of 100k
     """
-    _filter_name = "bzip2"
+    filter_name = "bzip2"
     filter_id = BZIP2_ID
 
     def __init__(self, blocksize=9) -> None:
@@ -250,7 +250,7 @@ class FciDecomp(_FilterRefClass):
             **hdf5plugin.FciDecomp())
         f.close()
     """
-    _filter_name = "fcidecomp"
+    filter_name = "fcidecomp"
     filter_id = FCIDECOMP_ID
 
     def __init__(self, *args, **kwargs):
@@ -278,7 +278,7 @@ class LZ4(_FilterRefClass):
         It needs to be in the range of 0 < nbytes < 2113929216 (1,9GB).
         Default: 0 (for 1GB per block).
     """
-    _filter_name = "lz4"
+    filter_name = "lz4"
     filter_id = LZ4_ID
 
     def __init__(self, nbytes=0):
@@ -368,7 +368,7 @@ class Zfp(_FilterRefClass):
     :param int minexp: Smallest absolute bit plane number encoded.
         It controls the absolute error.
     """
-    _filter_name = "zfp"
+    filter_name = "zfp"
     filter_id = ZFP_ID
 
     def __init__(self,
@@ -463,7 +463,7 @@ class SZ(_FilterRefClass):
               **hdf5plugin.SZ(pointwise_relative=0.01))
 
     """
-    _filter_name = "sz"
+    filter_name = "sz"
     filter_id = SZ_ID
 
     def __init__(self, absolute=None, relative=None, pointwise_relative=1e-05):
@@ -522,7 +522,7 @@ class Zstd(_FilterRefClass):
             **hdf5plugin.Zstd(clevel=22))
         f.close()
     """
-    _filter_name = "zstd"
+    filter_name = "zstd"
     filter_id = ZSTD_ID
 
     def __init__(self, clevel=3):
@@ -533,5 +533,5 @@ class Zstd(_FilterRefClass):
 FILTER_CLASSES = Bitshuffle, Blosc, BZip2, FciDecomp, LZ4, SZ, Zfp, Zstd
 
 
-FILTERS = dict((cls._filter_name, cls.filter_id) for cls in FILTER_CLASSES)
+FILTERS = dict((cls.filter_name, cls.filter_id) for cls in FILTER_CLASSES)
 """Mapping of provided filter's name to their HDF5 filter ID."""

--- a/src/hdf5plugin/_utils.py
+++ b/src/hdf5plugin/_utils.py
@@ -156,14 +156,13 @@ def get_config():
 
 
 def get_filters(filters=tuple(FILTERS.keys())):
-    """Returns selected filter classes
+    """Returns selected filter classes.
 
     By default it returns all filter classes.
 
     :param Union[str,int,Tuple[Union[str,int]] filters:
-        Filter name or ID or sequence of filter names or IDs.
-        The default is all filters.
-        It also supports the value `"registered"` with selects
+        Filter name or ID or sequence of filter names or IDs (default: all filters).
+        It also supports the value `"registered"` which selects
         currently available filters.
     :return: Tuple of filter classes
     """

--- a/src/hdf5plugin/_utils.py
+++ b/src/hdf5plugin/_utils.py
@@ -188,21 +188,21 @@ def get_filters(filters=tuple(FILTERS.keys())):
 
 
 def register(filters=tuple(FILTERS.keys()), force=True):
-    """Initialise and register `hdf5plugin` embedded filters given their names.
+    """Initialise and register `hdf5plugin` embedded filters given their names or IDs.
 
-    :param Union[str.Tuple[str]] filters:
-        Filter name or sequence of filter names (See `hdf5plugin.FILTERS`).
+    :param Union[str,int,Tuple[Union[str,int]] filters:
+        Filter name or ID or sequence of filter names or IDs.
     :param bool force:
         True to register the filter even if a corresponding one if already available.
         False to skip already available filters.
     :return: True if all filters were registered successfully, False otherwise.
     :rtype: bool
     """
-    if isinstance(filters, str):
-        filters = (filters,)
+    filter_classes = get_filters(filters)
 
     status = True
-    for filter_name in filters:
+    for filter_class in filter_classes:
+        filter_name = filter_class.filter_name
         if not force and is_filter_available(filter_name) is True:
             logger.info(f"{filter_name} filter already loaded, skip it.")
             continue

--- a/src/hdf5plugin/_utils.py
+++ b/src/hdf5plugin/_utils.py
@@ -177,7 +177,7 @@ def get_filters(filters=tuple(FILTERS.keys())):
             raise ValueError(f"Expected int or str, not {type(name_or_id)}")
 
         for cls in FILTER_CLASSES:
-            if ((isinstance(name_or_id, str) and cls._filter_name == name_or_id.lower()) or
+            if ((isinstance(name_or_id, str) and cls.filter_name == name_or_id.lower()) or
                 (isinstance(name_or_id, int) and cls.filter_id == name_or_id)):
                     filter_classes.append(cls)
                     break

--- a/src/hdf5plugin/_utils.py
+++ b/src/hdf5plugin/_utils.py
@@ -206,7 +206,7 @@ def register(filters=tuple(FILTERS.keys()), force=True):
         if not force and is_filter_available(filter_name) is True:
             logger.info(f"{filter_name} filter already loaded, skip it.")
             continue
-        status = status and register_filter(filter_name)
+        status = register_filter(filter_name) and status
     return status
 
 register(force=False)

--- a/src/hdf5plugin/test.py
+++ b/src/hdf5plugin/test.py
@@ -314,11 +314,22 @@ class TestRegisterFilter(BaseTestHDF5PluginRW):
 
     @unittest.skipIf(h5py.version.version_tuple < (2, 10), "h5py<2.10: unregister_filer not available")
     @unittest.skipUnless(BUILD_CONFIG.embedded_filters, "No embedded filters")
-    def test_register_single_filter(self):
-        """Re-register embedded filters one at a time"""
+    def test_register_single_filter_by_name(self):
+        """Re-register embedded filters one at a time given their name"""
         for filter_name in BUILD_CONFIG.embedded_filters:
             with self.subTest(name=filter_name):
                 status = hdf5plugin.register(filter_name, force=True)
+                self.assertTrue(status)
+                self._simple_test(filter_name)
+
+    @unittest.skipIf(h5py.version.version_tuple < (2, 10), "h5py<2.10: unregister_filer not available")
+    @unittest.skipUnless(BUILD_CONFIG.embedded_filters, "No embedded filters")
+    def test_register_single_filter_by_id(self):
+        """Re-register embedded filters one at a time given their ID"""
+        for filter_name in BUILD_CONFIG.embedded_filters:
+            with self.subTest(name=filter_name):
+                filter_class = hdf5plugin.get_filters(filter_name)[0]
+                status = hdf5plugin.register(filter_class.filter_id, force=True)
                 self.assertTrue(status)
                 self._simple_test(filter_name)
 

--- a/src/hdf5plugin/test.py
+++ b/src/hdf5plugin/test.py
@@ -346,7 +346,7 @@ class TestGetFilters(unittest.TestCase):
         filters = hdf5plugin.get_filters("registered")
         self.assertTrue(set(filters).issubset(_filters.FILTER_CLASSES))
 
-        filter_names = set(f._filter_name for f in filters)
+        filter_names = set(f.filter_name for f in filters)
         registered_names = set(hdf5plugin.get_config().registered_filters.keys())
         self.assertEqual(filter_names, registered_names)
 


### PR DESCRIPTION
This PR adds a `get_filters` function to retrieve filter classes from names or IDs.
By default is returns all filter classes.
It accepts a special argument "registered" and then returns classes of all currently registered filters.

The `register` function was also extended to supports IDs.
The `FILTERS` constant was removed from the documentation (not deprecated though): one can get filter classes with `get_filters` and then retrieve the `filter_id` from the filter classes.

A `filter_name` class attribute was also added to filter classes so one can get it from a class and it is shown in the documentation along with the classes.
Question: Is it really worth adding this `filter_name` which is specific to `hdf5plugin` to the API or not?

@rayosborn would that fits your need?

This PR also fixes a bug in `register` when one filter fails to register, the other are skipped: [58c56eb](https://github.com/silx-kit/hdf5plugin/pull/212/commits/58c56eb77006fd5b69368f0bc44e45071510827d)

closes #207