### PR TITLE
Fixed code style; Deprecated `date`, `hexversion` and `strictversion`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E203, E501
+max-line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -178,8 +178,9 @@ class HostConfig:
         if self.arch in ('X86_32', 'X86_64'):
             if not has_cpu_flag('sse2'):
                 return False  # SSE2 not available on host
-            return (self.__compiler.compiler_type == 'msvc' or
-                    check_compile_flags(self.__compiler, '-msse2'))
+            return self.__compiler.compiler_type == "msvc" or check_compile_flags(
+                self.__compiler, "-msse2"
+            )
         if self.machine == 'ppc64le':
             return True
         return False  # Disabled by default
@@ -220,7 +221,7 @@ class BuildConfig:
             use_avx2=None,
             use_openmp=None,
             use_native=None,
-        ):
+    ):
 
         self.__config_file = str(config_file)
 
@@ -307,7 +308,7 @@ build_config = HDF5PluginBuildConfig(**{config})
         try:
             with open(self.__config_file, 'r') as f:
                 return f.read() != self.get_config_string()
-        except:
+        except:  # noqa
             pass
         return True
 
@@ -329,7 +330,7 @@ class Build(build):
         ('sse2=', None, "Deprecated, use HDF5PLUGIN_SSE2 environment variable"),
         ('avx2=', None, "Deprecated, use HDF5PLUGIN_AVX2 environment variable"),
         ('cpp11=', None, "Deprecated, use HDF5PLUGIN_CPP11 environment variable"),
-        ]
+    ]
     user_options.extend(build.user_options)
 
     boolean_options = build.boolean_options + ['openmp', 'native', 'sse2', 'avx2', 'cpp11']
@@ -568,12 +569,12 @@ else:
     sse2_kwargs = {
         'sources': [f for f in glob(blosc_dir + 'blosc/*.c') if 'sse2' in f],
         'define_macros': [('SHUFFLE_SSE2_ENABLED', 1)],
-        }
+    }
 
 avx2_kwargs = {
     'sources': [f for f in glob(blosc_dir + 'blosc/*.c') if 'avx2' in f],
     'define_macros': [('SHUFFLE_AVX2_ENABLED', 1)],
-    }
+}
 
 # compression libs
 # lz4
@@ -602,9 +603,9 @@ cpp11_kwargs = {
     'include_dirs': glob(snappy_dir),
     'extra_link_args': ['-lstdc++'],
     'define_macros': [('HAVE_SNAPPY', 1)],
-    }
+}
 
-#zlib
+# zlib
 zlib_sources = glob(blosc_dir + 'internal-complibs/zlib*/*.c')
 zlib_depends = glob(blosc_dir + 'internal-complibs/zlib*/*.h')
 zlib_include_dirs = glob(blosc_dir + 'internal-complibs/zlib*')
@@ -615,15 +616,15 @@ include_dirs += zlib_include_dirs
 define_macros.append(('HAVE_ZLIB', 1))
 
 # zstd
-zstd_sources = glob(blosc_dir +'internal-complibs/zstd*/*/*.c')
+zstd_sources = glob(blosc_dir + 'internal-complibs/zstd*/*/*.c')
 if os.environ.get("HDF5PLUGIN_BMI2", 'True') == 'True' and (sys.platform.startswith('linux') or sys.platform.startswith('macos')):
-    zstd_extra_objects = glob(blosc_dir +'internal-complibs/zstd*/*/*.S')
+    zstd_extra_objects = glob(blosc_dir + 'internal-complibs/zstd*/*/*.S')
     zstd_define_macros = []
 else:
     zstd_extra_objects = []
     zstd_define_macros = [('ZSTD_DISABLE_ASM', 1)]
 
-zstd_depends = glob(blosc_dir +'internal-complibs/zstd*/*/*.h')
+zstd_depends = glob(blosc_dir + 'internal-complibs/zstd*/*/*.h')
 zstd_include_dirs = glob(blosc_dir + 'internal-complibs/zstd*')
 zstd_include_dirs += glob(blosc_dir + 'internal-complibs/zstd*/common')
 
@@ -641,11 +642,11 @@ extra_link_args = ['-pthread']
 
 blosc_plugin = HDF5PluginExtension(
     "hdf5plugin.plugins.libh5blosc",
-    sources=sources + \
-        prefix(hdf5_blosc_dir,['blosc_filter.c', 'blosc_plugin.c']),
+    sources=sources + prefix(
+        hdf5_blosc_dir, ['blosc_filter.c', 'blosc_plugin.c']),
     extra_objects=zstd_extra_objects,
-    depends=depends + \
-        prefix(hdf5_blosc_dir, ['blosc_filter.h', 'blosc_plugin.h']),
+    depends=depends + prefix(
+        hdf5_blosc_dir, ['blosc_filter.h', 'blosc_plugin.h']),
     include_dirs=include_dirs + [hdf5_blosc_dir],
     define_macros=define_macros,
     extra_compile_args=extra_compile_args,
@@ -653,7 +654,7 @@ blosc_plugin = HDF5PluginExtension(
     sse2=sse2_kwargs,
     avx2=avx2_kwargs,
     cpp11=cpp11_kwargs,
-    )
+)
 PLUGIN_LIB_DEPENDENCIES['blosc'] = 'snappy'
 
 
@@ -670,7 +671,7 @@ zstandard_plugin = HDF5PluginExtension(
     depends=zstandard_depends,
     include_dirs=zstd_include_dirs,
     define_macros=zstd_define_macros,
-    )
+)
 
 # bitshuffle (+lz4 or zstd) plugin
 # Plugins from https://github.com/kiyo-masui/bitshuffle
@@ -681,7 +682,7 @@ extra_compile_args = ['-O3', '-ffast-math', '-std=c99', '-fopenmp']
 extra_compile_args += ['/Ox', '/fp:fast', '/openmp']
 if platform.machine() == "ppc64le":
     # Required on ppc64le
-    sse2_options = {'extra_compile_args': ['-DUSESSE2'] }
+    sse2_options = {'extra_compile_args': ['-DUSESSE2']}
 else:
     sse2_options = {}
 extra_link_args = ['-fopenmp', '/openmp']
@@ -689,22 +690,23 @@ define_macros = [("ZSTD_SUPPORT", 1)]
 
 bithsuffle_plugin = HDF5PluginExtension(
     "hdf5plugin.plugins.libh5bshuf",
-    sources=prefix(bithsuffle_dir,
-        ["src/bshuf_h5plugin.c", "src/bshuf_h5filter.c",
-         "src/bitshuffle.c", "src/bitshuffle_core.c",
-         "src/iochain.c", "lz4/lz4.c"]) + zstd_sources,
+    sources=prefix(bithsuffle_dir, [
+        "src/bshuf_h5plugin.c", "src/bshuf_h5filter.c",
+        "src/bitshuffle.c", "src/bitshuffle_core.c",
+        "src/iochain.c", "lz4/lz4.c"
+    ]) + zstd_sources,
     extra_objects=zstd_extra_objects,
-    depends=prefix(bithsuffle_dir,
-        ["src/bitshuffle.h", "src/bitshuffle_core.h",
-         "src/iochain.h", 'src/bshuf_h5filter.h',
-         "lz4/lz4.h"]) + zstd_depends,
+    depends=prefix(bithsuffle_dir, [
+        "src/bitshuffle.h", "src/bitshuffle_core.h",
+        "src/iochain.h", 'src/bshuf_h5filter.h',
+        "lz4/lz4.h"
+    ]) + zstd_depends,
     include_dirs=prefix(bithsuffle_dir, ['src/', 'lz4/']) + zstd_include_dirs,
     define_macros=define_macros + zstd_define_macros,
     extra_compile_args=extra_compile_args,
     extra_link_args=extra_link_args,
     sse2=sse2_options,
-    )
-
+)
 
 
 # lz4 plugin
@@ -721,7 +723,7 @@ lz4_plugin = HDF5PluginExtension(
     include_dirs=lz4_include_dirs,
     extra_compile_args=extra_compile_args,
     libraries=['Ws2_32'] if sys.platform.startswith('win') else [],
-    )
+)
 
 
 # BZIP2
@@ -746,7 +748,7 @@ bzip2_plugin = HDF5PluginExtension(
     include_dirs=['src/PyTables/src/'] + bzip2_include_dirs,
     define_macros=[('HAVE_BZ2_LIB', 1)],
     extra_compile_args=bzip2_extra_compile_args,
-    )
+)
 
 # FCIDECOMP
 fcidecomp_dir = 'src/fcidecomp/FCIDECOMP_V1.0.2/Software/FCIDECOMP_SOURCES'
@@ -765,10 +767,10 @@ for item in fcidecomp_additional_dirs:
     depends += glob(fcidecomp_dir + "/" + item + "/include/*.h")
     include_dirs += [fcidecomp_dir + "/" + item + "/include",
                      "src/charls/src"]
-    #include_dirs += ["src/hdf5"]
+    # include_dirs += ["src/hdf5"]
 cpp11_kwargs = {
     'extra_link_args': ['-lstdc++'],
-    }
+}
 fcidecomp_plugin = HDF5PluginExtension(
     "hdf5plugin.plugins.libh5fcidecomp",
     sources=sources,
@@ -780,7 +782,7 @@ fcidecomp_plugin = HDF5PluginExtension(
     cpp11=cpp11_kwargs,
     cpp11_required=True,
     define_macros=[('CHARLS_STATIC', 1)],
-    )
+)
 PLUGIN_LIB_DEPENDENCIES['fcidecomp'] = 'charls'
 
 
@@ -796,7 +798,7 @@ charls_lib = ('charls', {
 cpp11_kwargs = {
     'include_dirs': glob('charls_dir/src'),
     'extra_link_args': ['-lstdc++'],
-    }
+}
 
 # H5Z-ZFP
 h5zfp_dir = 'src/H5Z-ZFP/src'
@@ -814,7 +816,7 @@ h5zfp_plugin = HDF5PluginExtension(
     include_dirs=include_dirs,
     extra_compile_args=extra_compile_args,
     extra_link_args=extra_link_args,
-    )
+)
 PLUGIN_LIB_DEPENDENCIES['zfp'] = 'zfp'
 
 # zfp
@@ -825,7 +827,7 @@ zfp_lib = ('zfp', {
     'sources': zfp_sources,
     'include_dirs': zfp_include_dirs,
     'cflags': ['-DBIT_STREAM_WORD_TYPE=uint8'],
-    })
+})
 
 # SZ library and its hdf5 filter
 sz_dir = os.path.join("src", "SZ", "sz")
@@ -891,9 +893,10 @@ def apply_filter_strip(libraries, extensions, dependencies):
     # Filter out stripped filters
     extensions = [
         ext for ext in extensions
-        if isinstance(ext, HDF5PluginExtension) and  ext.hdf5_plugin_name not in stripped_filters
+        if isinstance(ext, HDF5PluginExtension) and ext.hdf5_plugin_name not in stripped_filters
     ]
     return libraries, extensions
+
 
 libraries, extensions = apply_filter_strip(
     libraries=[snappy_lib, charls_lib, zfp_lib],
@@ -992,9 +995,9 @@ PROJECT = 'hdf5plugin'
 author = "ESRF - Data Analysis Unit"
 author_email = "silx@esrf.fr"
 description = "HDF5 Plugins for Windows, MacOS, and Linux"
-url='https://github.com/silx-kit/hdf5plugin'
+url = 'https://github.com/silx-kit/hdf5plugin'
 f = open("README.rst")
-long_description=f.read()
+long_description = f.read()
 f.close()
 license = "https://github.com/silx-kit/hdf5plugin/blob/master/LICENSE"
 classifiers = ["Development Status :: 5 - Production/Stable",

--- a/src/hdf5plugin/__init__.py
+++ b/src/hdf5plugin/__init__.py
@@ -27,8 +27,8 @@ under windows, MacOS and linux."""
 
 import logging as _logging
 
-from ._version import __date__ as date  # noqa
-from ._version import version, version_info, hexversion, strictversion  # noqa
+from . import _version
+from ._version import version, version_info  # noqa
 
 from ._filters import FILTERS  # noqa
 from ._filters import BLOSC_ID, Blosc  # noqa
@@ -52,4 +52,9 @@ def __getattr__(name):
             "hdf5plugin.config is deprecated, use get_config().build_config"
         )
         return get_config().build_config
+    if name in ("date", "hexversion", "strictversion"):
+        _logging.getLogger(__name__).warning(
+            f"hdf5plugin.{name} is deprecated"
+        )
+        return getattr(_version, name)
     raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/src/hdf5plugin/__init__.py
+++ b/src/hdf5plugin/__init__.py
@@ -45,6 +45,7 @@ from ._utils import get_config, get_filters, PLUGIN_PATH, register  # noqa
 # Backward compatibility
 PLUGINS_PATH = PLUGIN_PATH
 
+
 def __getattr__(name):
     if name == "config":
         _logging.getLogger(__name__).warning(

--- a/src/hdf5plugin/_filters.py
+++ b/src/hdf5plugin/_filters.py
@@ -406,10 +406,10 @@ class Zfp(_FilterRefClass):
             minexp = struct.unpack('I', struct.pack('i', int(minexp)))[0]
             self.filter_options = 4, 0, minbits, maxbits, maxprec, minexp
             logger.info("ZFP mode 4 used. H5Z_ZFP_MODE_EXPERT")
-        
+
         else:
-           logger.info("ZFP default used")
-        
+            logger.info("ZFP default used")
+
         logger.info(f"filter options = {self.filter_options}")
 
 

--- a/src/hdf5plugin/_utils.py
+++ b/src/hdf5plugin/_utils.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 
 PLUGIN_PATH = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), 'plugins'))
+    os.path.join(os.path.dirname(__file__), 'plugins'))
 """Directory where the provided HDF5 filter plugins are stored."""
 
 
@@ -56,7 +56,7 @@ def is_filter_available(name):
 
     hdf5_version = h5py.h5.get_libversion()
     if hdf5_version < (1, 8, 20) or (1, 10) <= hdf5_version < (1, 10, 2):
-        return None # h5z.filter_avail not available
+        return None  # h5z.filter_avail not available
     return h5py.h5z.filter_avail(filter_id) > 0
 
 
@@ -177,10 +177,11 @@ def get_filters(filters=tuple(FILTERS.keys())):
             raise ValueError(f"Expected int or str, not {type(name_or_id)}")
 
         for cls in FILTER_CLASSES:
-            if ((isinstance(name_or_id, str) and cls.filter_name == name_or_id.lower()) or
-                (isinstance(name_or_id, int) and cls.filter_id == name_or_id)):
-                    filter_classes.append(cls)
-                    break
+            if (
+                isinstance(name_or_id, str) and cls.filter_name == name_or_id.lower()
+            ) or (isinstance(name_or_id, int) and cls.filter_id == name_or_id):
+                filter_classes.append(cls)
+                break
         else:
             raise ValueError(f"Unknown filter: {name_or_id}")
 
@@ -208,5 +209,6 @@ def register(filters=tuple(FILTERS.keys()), force=True):
             continue
         status = register_filter(filter_name) and status
     return status
+
 
 register(force=False)

--- a/src/hdf5plugin/_version.py
+++ b/src/hdf5plugin/_version.py
@@ -48,6 +48,7 @@ Bits (big endian order)     Meaning
 Thus 2.1.0a3 is hexversion 0x020100a3.
 
 """
+from collections import namedtuple
 
 __authors__ = ["Jérôme Kieffer"]
 __license__ = "MIT"
@@ -77,7 +78,6 @@ SERIAL = 0  # <16
 
 date = __date__
 
-from collections import namedtuple
 _version_info = namedtuple("version_info", ["major", "minor", "micro", "releaselevel", "serial"])
 
 version_info = _version_info(MAJOR, MINOR, MICRO, RELEV, SERIAL)

--- a/src/hdf5plugin/test.py
+++ b/src/hdf5plugin/test.py
@@ -146,7 +146,7 @@ class TestHDF5PluginRW(BaseTestHDF5PluginRW):
             for dtype in (numpy.int8, numpy.int16, numpy.int32, numpy.int64):
                 for nelems in (1024, 2048):
                     with self.subTest(cname=cname, dtype=dtype, nelems=nelems):
-                        filter_ = self._test('bshuf', dtype, compressed=cname!='none', nelems=nelems, cname=cname)
+                        filter_ = self._test('bshuf', dtype, compressed=cname != 'none', nelems=nelems, cname=cname)
                         self.assertEqual(filter_[2][3:5], (nelems, compression_ids[cname]))
 
     @unittest.skipUnless(should_test("blosc"), "Blosc filter not available")
@@ -169,7 +169,7 @@ class TestHDF5PluginRW(BaseTestHDF5PluginRW):
                             self.skipTest("snappy unavailable without C++11")
                         filter_ = self._test(
                             'blosc',
-                            compressed=clevel!=0,  # No compression for clevel=0
+                            compressed=clevel != 0,  # No compression for clevel=0
                             cname=cname,
                             clevel=clevel,
                             shuffle=shuffle)
@@ -227,7 +227,7 @@ class TestHDF5PluginRW(BaseTestHDF5PluginRW):
             {'lossless': True, 'reversible': True},  # Reversible
             # Expert: with default parameters
             {'lossless': False, 'minbits': 1, 'maxbits': 16657, 'maxprec': 64, 'minexp': -1074},
-            ]
+        ]
         for options in tests:
             for dtype in (numpy.float32, numpy.float64):
                 with self.subTest(options=options, dtype=dtype):


### PR DESCRIPTION
~~Merge PR  #215 first!~~

This PR: 
- [Fixes code style with flake8](https://github.com/silx-kit/hdf5plugin/commit/72a372410d5a68b87d4059e45bdac5120209a50b)
- [Adds flake8 config](https://github.com/silx-kit/hdf5plugin/commit/042d29107a9ac3ae5642c0a3aad5d4fa0da6c0e7)
- [Deprecates date, hexversion, strictversion](https://github.com/silx-kit/hdf5plugin/commit/b90d230f6be6476986d1e2780d39de61f489873e)
- ~~Proposes to [stop using FILTER_ID](https://github.com/silx-kit/hdf5plugin/commit/be278422d7ab7d8cb6020e97c1910bee3d94cdab) in favor of `Filter.filter_id`: So remove `FILTER_ID` introduced since last version.~~