### PR TITLE
Skip zstd test in inner iteration

### DIFF
--- a/src/hdf5plugin/test.py
+++ b/src/hdf5plugin/test.py
@@ -143,6 +143,8 @@ class TestHDF5PluginRW(BaseTestHDF5PluginRW):
 
         # Specify options
         for cname in ('none', 'lz4', 'zstd'):
+            if cname != "none" and not should_test(cname):
+                continue
             for dtype in (numpy.int8, numpy.int16, numpy.int32, numpy.int64):
                 for nelems in (1024, 2048):
                     with self.subTest(cname=cname, dtype=dtype, nelems=nelems):


### PR DESCRIPTION
There is currently no zstd filter plugin in Debian. The test suite of python-hdf5plugin knows how to skip zstd tests accordingly, except for one inner iteration, which needs this extra check