### PR TITLE
Updated build setup to share some build steps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -595,6 +595,22 @@ def get_snappy_clib(field=None):
     return config[field]
 
 
+def get_zfp_clib():
+    """ZFP static lib build config"""
+    cflags = ['-O3', '-ffast-math', '-std=c99']  # TODO, '-fopenmp']
+    cflags += ['/Ox', '/fp:fast', '/openmp']
+
+    zfp_dir = os.path.join("src", "zfp")
+    zfp_sources = glob(os.path.join(zfp_dir, 'src', '*.c'))
+    zfp_include_dirs = [os.path.join(zfp_dir, 'include')]
+    return ('zfp', {
+        'sources': zfp_sources,
+        'include_dirs': zfp_include_dirs,
+        'macros': [('BIT_STREAM_WORD_TYPE', 'uint8')],
+        'cflags': cflags,
+    })
+
+
 def get_zlib_clib(field=None):
     """ZLib static lib build config"""
     cflags = ['-O3', '-ffast-math', '-std=gnu99']
@@ -879,18 +895,6 @@ def get_h5zfp_plugin():
         extra_compile_args=extra_compile_args,
         extra_link_args=extra_link_args,
     )
-
-
-def get_zfp_clib():
-    """ZFP static lib build config"""
-    zfp_dir = os.path.join("src", "zfp")
-    zfp_sources = glob(os.path.join(zfp_dir, 'src', '*.c'))
-    zfp_include_dirs = [os.path.join(zfp_dir, 'include')]
-    return ('zfp', {
-        'sources': zfp_sources,
-        'include_dirs': zfp_include_dirs,
-        'cflags': ['-DBIT_STREAM_WORD_TYPE=uint8'],
-    })
 
 
 PLUGIN_LIB_DEPENDENCIES['zfp'] = ('zfp',)

--- a/setup.py
+++ b/setup.py
@@ -159,11 +159,11 @@ class HostConfig:
 
     def get_shared_lib_extension(self) -> str:
         """Returns shared library file extension"""
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             return '.dll'
-        elif sys.platform.startswith('linux'):
+        elif sys.platform == 'linux':
             return '.so'
-        elif sys.platform.startswith('darwin'):
+        elif sys.platform == 'darwin':
             return '.dylib'
         else:  # Return same value as used by build_ext.get_ext_filename
             return sysconfig.get_config_var('EXT_SUFFIX')
@@ -198,7 +198,7 @@ class HostConfig:
 
     def has_openmp(self) -> bool:
         """Check OpenMP availability on host"""
-        if sys.platform.startswith('darwin'):
+        if sys.platform == 'darwin':
             return False
         prefix = '/' if self.__compiler.compiler_type == 'msvc' else '-f'
         return check_compile_flags(self.__compiler, prefix + 'openmp')
@@ -502,10 +502,10 @@ class HDF5PluginExtension(Extension):
                 glob(f"{self.include_dirs}/*.hpp")))
 
         self.export_symbols.append('H5PLget_plugin_info')
-        if not sys.platform.startswith('win'):
+        if not sys.platform == 'win32':
             self.export_symbols.append('init_filter')
 
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             self.define_macros.append(('H5_BUILT_AS_DYNAMIC_LIB', None))
             self.libraries.append('hdf5')
 
@@ -527,13 +527,13 @@ class HDF5PluginExtension(Extension):
         if hdf5_dir is None:
             hdf5_dir = os.path.join('src', 'hdf5')
             # Add folder containing H5pubconf.h
-            if sys.platform.startswith('win'):
+            if sys.platform == 'win32':
                 folder = 'windows'
             else:
-                folder = 'darwin' if sys.platform.startswith('darwin') else 'linux'
+                folder = 'darwin' if sys.platform == 'darwin' else 'linux'
             self.include_dirs.insert(0, os.path.join(hdf5_dir, 'include', folder))
 
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             self.library_dirs.insert(0, os.path.join(hdf5_dir, 'lib'))
         self.include_dirs.insert(0, os.path.join(hdf5_dir, 'include'))
 
@@ -805,7 +805,7 @@ def get_lz4_plugin():
 
     Source from https://github.com/nexusformat/HDF5-External-Filter-Plugins
     """
-    if sys.platform.startswith('darwin'):
+    if sys.platform == 'darwin':
         extra_compile_args = ['-Wno-error=implicit-function-declaration']
     else:
         extra_compile_args = []
@@ -815,7 +815,7 @@ def get_lz4_plugin():
         sources=['src/LZ4/H5Zlz4.c', 'src/LZ4/lz4_h5plugin.c'],
         include_dirs=get_lz4_clib('include_dirs'),
         extra_compile_args=extra_compile_args,
-        libraries=['Ws2_32'] if sys.platform.startswith('win') else [],
+        libraries=['Ws2_32'] if sys.platform == 'win32' else [],
     )
 
 
@@ -935,7 +935,7 @@ def get_sz3_plugin():
     include_dirs += glob(f"{sz3_dir}/include/SZ3/utils/*/")
     # add version.hpp
     include_dirs.append("src/SZ3_extra")
-    if sys.platform.startswith('darwin'):
+    if sys.platform == 'darwin':
         # provide dummy omp.h
         include_dirs.append("src/SZ3_extra/darwin")
     include_dirs.append(f"{h5z_sz3_dir}/include")
@@ -1021,9 +1021,9 @@ def get_hdf5_dl_clib():
     hdf5_dir = os.environ.get("HDF5PLUGIN_HDF5_DIR", None)
     if hdf5_dir is None:
         hdf5_dir = "src/hdf5"
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             folder = 'windows'
-        elif sys.platform.startswith('darwin'):
+        elif sys.platform == 'darwin':
             folder = 'darwin'
         else:
             folder = 'linux'
@@ -1038,7 +1038,7 @@ def get_hdf5_dl_clib():
     })
 
 
-if extensions and not sys.platform.startswith('win'):
+if extensions and not sys.platform == 'win32':
     libraries.append(get_hdf5_dl_clib())
 
 

--- a/setup.py
+++ b/setup.py
@@ -765,13 +765,12 @@ def get_zstandard_plugin():
 PLUGIN_LIB_DEPENDENCIES['zstd'] = ('zstd',)
 
 
-# TODO use lz4 clib for bitshuffle
 def get_bitshuffle_plugin():
     """bitshuffle (+lz4 or zstd) plugin build config
 
     Plugins from https://github.com/kiyo-masui/bitshuffle
     """
-    bithsuffle_dir = 'src/bitshuffle'
+    bithsuffle_dir = 'src/bitshuffle/src'
 
     extra_compile_args = ['-O3', '-ffast-math', '-std=c99', '-fopenmp']
     extra_compile_args += ['/Ox', '/fp:fast', '/openmp']
@@ -784,12 +783,14 @@ def get_bitshuffle_plugin():
     return HDF5PluginExtension(
         "hdf5plugin.plugins.libh5bshuf",
         sources=prefix(bithsuffle_dir, [
-            "src/bshuf_h5plugin.c", "src/bshuf_h5filter.c",
-            "src/bitshuffle.c", "src/bitshuffle_core.c",
-            "src/iochain.c", "lz4/lz4.c"
+            "bshuf_h5plugin.c",
+            "bshuf_h5filter.c",
+            "bitshuffle.c",
+            "bitshuffle_core.c",
+            "iochain.c",
         ]),
         extra_objects=get_zstd_clib('extra_objects'),
-        include_dirs=prefix(bithsuffle_dir, ['src/', 'lz4/']) + get_zstd_clib('include_dirs'),
+        include_dirs=[bithsuffle_dir] + get_lz4_clib('include_dirs') + get_zstd_clib('include_dirs'),
         define_macros=[("ZSTD_SUPPORT", 1)],
         extra_compile_args=extra_compile_args,
         extra_link_args=extra_link_args,
@@ -797,7 +798,7 @@ def get_bitshuffle_plugin():
     )
 
 
-PLUGIN_LIB_DEPENDENCIES['bshuf'] = ('zstd',)
+PLUGIN_LIB_DEPENDENCIES['bshuf'] = ('lz4', 'zstd')
 
 
 def get_lz4_plugin():

--- a/setup.py
+++ b/setup.py
@@ -555,15 +555,18 @@ PLUGIN_LIB_DEPENDENCIES = dict()
 
 # compression libs
 
-def get_charls_clib():
+def get_charls_clib(field=None):
     """CharLS static lib build config"""
     charls_dir = "src/charls/src"
-    charls_sources = glob(charls_dir + '/*.cpp')
-    charls_include_dirs = [charls_dir]
-    return ('charls', {
-        'sources': charls_sources,
-        'include_dirs': charls_include_dirs,
-        'cflags': ['-std=c++11']})
+    config = {
+        'sources': glob(f'{charls_dir}/*.cpp'),
+        'include_dirs': [charls_dir],
+        'cflags': ['-std=c++11'],
+    }
+
+    if field is None:
+        return 'charls', config
+    return config[field]
 
 
 def get_lz4_clib(field=None):
@@ -852,7 +855,7 @@ def get_fcidecomp_plugin():
     for item in fcidecomp_additional_dirs:
         sources += glob(fcidecomp_dir + "/" + item + "/src/*.c")
         depends += glob(fcidecomp_dir + "/" + item + "/include/*.h")
-        include_dirs += [fcidecomp_dir + "/" + item + "/include", "src/charls/src"]
+        include_dirs += [fcidecomp_dir + "/" + item + "/include"]
         # include_dirs += ["src/hdf5"]
     cpp11_kwargs = {
         'extra_link_args': ['-lstdc++'],
@@ -861,7 +864,7 @@ def get_fcidecomp_plugin():
         "hdf5plugin.plugins.libh5fcidecomp",
         sources=sources,
         depends=depends,
-        include_dirs=include_dirs,
+        include_dirs=include_dirs + get_charls_clib('include_dirs'),
         extra_compile_args=extra_compile_args,
         extra_link_args=extra_link_args,
         # export_symbols=['init_filter'],
@@ -872,13 +875,6 @@ def get_fcidecomp_plugin():
 
 
 PLUGIN_LIB_DEPENDENCIES['fcidecomp'] = ('charls',)
-
-
-# TODO not needed!
-cpp11_kwargs = {
-    'include_dirs': glob('charls_dir/src'),
-    'extra_link_args': ['-lstdc++'],
-}
 
 
 def get_h5zfp_plugin():

--- a/setup.py
+++ b/setup.py
@@ -411,11 +411,15 @@ class BuildCLib(build_clib):
     def build_libraries(self, libraries):
         updated_libraries = []
         for (lib_name, build_info) in libraries:
+            config = self.distribution.get_command_obj("build").hdf5plugin_config
+
             cflags = list(build_info.get('cflags', []))
 
             # Add flags from build config
-            config = self.distribution.get_command_obj("build").hdf5plugin_config
             cflags.extend(config.compile_args)
+
+            if not config.use_openmp:  # Remove OpenMP flags
+                cflags = [f for f in cflags if not f.endswith('openmp')]
 
             prefix = '/' if self.compiler.compiler_type == 'msvc' else '-'
             build_info['cflags'] = [
@@ -597,7 +601,7 @@ def get_snappy_clib(field=None):
 
 def get_zfp_clib():
     """ZFP static lib build config"""
-    cflags = ['-O3', '-ffast-math', '-std=c99']  # TODO, '-fopenmp']
+    cflags = ['-O3', '-ffast-math', '-std=c99', '-fopenmp']
     cflags += ['/Ox', '/fp:fast', '/openmp']
 
     zfp_dir = os.path.join("src", "zfp")

--- a/setup.py
+++ b/setup.py
@@ -551,6 +551,17 @@ PLUGIN_LIB_DEPENDENCIES = dict()
 
 # compression libs
 
+def get_charls_clib():
+    """CharLS static lib build config"""
+    charls_dir = "src/charls/src"
+    charls_sources = glob(charls_dir + '/*.cpp')
+    charls_include_dirs = [charls_dir]
+    return ('charls', {
+        'sources': charls_sources,
+        'include_dirs': charls_include_dirs,
+        'cflags': ['-std=c++11']})
+
+
 def get_lz4_clib(field=None):
     """LZ4 static lib build config"""
     cflags = ['-O3', '-ffast-math', '-std=gnu99']
@@ -563,6 +574,24 @@ def get_lz4_clib(field=None):
     }
     if field is None:
         return 'lz4', config
+    return config[field]
+
+
+def get_snappy_clib(field=None):
+    """snappy static lib build config"""
+    snappy_dir = 'src/snappy'
+    config = {
+        'sources': prefix(snappy_dir, [
+            'snappy-c.cc',
+            'snappy-sinksource.cc',
+            'snappy-stubs-internal.cc',
+            'snappy.cc',
+        ]),
+        'include_dirs': glob(snappy_dir),
+        'cflags': ['-std=c++11'],
+    }
+    if field is None:
+        return 'snappy', config
     return config[field]
 
 
@@ -602,22 +631,7 @@ def get_zstd_clib(field=None):
     return config[field]
 
 
-def get_snappy_clib(field=None):
-    """snappy static lib build config"""
-    snappy_dir = 'src/snappy'
-    config = {
-        'sources': prefix(snappy_dir, [
-            'snappy-c.cc',
-            'snappy-sinksource.cc',
-            'snappy-stubs-internal.cc',
-            'snappy.cc',
-        ]),
-        'include_dirs': glob(snappy_dir),
-        'cflags': ['-std=c++11'],
-    }
-    if field is None:
-        return 'snappy', config
-    return config[field]
+# compression filter plugins
 
 
 def get_blosc_plugin():
@@ -838,17 +852,6 @@ def get_fcidecomp_plugin():
 
 
 PLUGIN_LIB_DEPENDENCIES['fcidecomp'] = ('charls',)
-
-
-def get_charls_clib():
-    """CharLS static lib build config"""
-    charls_dir = "src/charls/src"
-    charls_sources = glob(charls_dir + '/*.cpp')
-    charls_include_dirs = [charls_dir]
-    return ('charls', {
-        'sources': charls_sources,
-        'include_dirs': charls_include_dirs,
-        'cflags': ['-std=c++11']})
 
 
 # TODO not needed!

--- a/setup.py
+++ b/setup.py
@@ -940,131 +940,48 @@ def get_sz_plugin():
 PLUGIN_LIB_DEPENDENCIES['sz'] = ('zlib', 'zstd')
 
 
-# SZ3 library and its hdf5 filter
-sz3_dir = os.path.join("src", "SZ3")
-sz3_sources = []  # glob(os.path.join(sz3_dir, "tools", "sz3", "sz3.*pp"))
-sz3_include_dirs = [os.path.join(sz3_dir, "include"),
-                    os.path.join(sz3_dir, "include", "SZ3"),
-                    os.path.join(sz3_dir, "include", "SZ3", "api"),
-                    os.path.join(sz3_dir, "include", "SZ3", "compressor"),
-                    os.path.join(sz3_dir, "include", "SZ3", "encoder"),
-                    os.path.join(sz3_dir, "include", "SZ3", "frontend"),
-                    os.path.join(sz3_dir, "include", "SZ3", "lossless"),
-                    os.path.join(sz3_dir, "include", "SZ3", "predictor"),
-                    os.path.join(sz3_dir, "include", "SZ3", "preprocessor"),
-                    os.path.join(sz3_dir, "include", "SZ3", "quantizer"),
-                    os.path.join(sz3_dir, "include", "SZ3", "utils"),
-                    os.path.join(sz3_dir, "include", "SZ3", "utils", "inih"),
-                    os.path.join(sz3_dir, "include", "SZ3", "utils", "ska_hash"),
-                    ]
-# add version.hpp
-sz3_include_dirs.append(os.path.join("src", "SZ3_extra"))
-if sys.platform.startswith('darwin'):
-    # provide dummy omp.h
-    sz3_include_dirs.append(os.path.join("src", "SZ3_extra", "darwin"))
-
-sz3_hdf5_dir = os.path.join(sz3_dir, "tools", "H5Z-SZ3")
-
-# I have issues with the BMI on linux and Mac because of compiling Zstd separately
-
-if sys.platform.startswith('darwin'):
-    HDF5PLUGIN_ZSTD_FROM_BLOSC = False
-else:
-    HDF5PLUGIN_ZSTD_FROM_BLOSC = True
-
-if not HDF5PLUGIN_ZSTD_FROM_BLOSC:
-    sz3_zstd_cmake_list = [
-        './common/entropy_common.c',
-        './common/pool.c',
-        './common/threading.c',
-        './common/debug.c',
-        './common/xxhash.c',
-        './common/fse_decompress.c',
-        './common/zstd_common.c',
-        './common/error_private.c',
-        './compress/zstd_ldm.c',
-        './compress/zstd_lazy.c',
-        './compress/huf_compress.c',
-        './compress/zstd_opt.c',
-        './compress/zstd_double_fast.c',
-        './compress/zstd_compress.c',
-        './compress/zstd_compress_superblock.c',
-        './compress/zstd_compress_sequences.c',
-        './compress/zstd_compress_literals.c',
-        './compress/zstd_fast.c',
-        './compress/fse_compress.c',
-        './compress/zstdmt_compress.c',
-        './compress/hist.c',
-        './decompress/zstd_decompress.c',
-        './decompress/huf_decompress.c',
-        './decompress/zstd_ddict.c',
-        './decompress/zstd_decompress.c',
-        './decompress/zstd_decompress_block.c',
-        './deprecated/zbuff_common.c',
-        './deprecated/zbuff_compress.c',
-        './deprecated/zbuff_decompress.c',
-        './legacy/zstd_v05.c',
-        './legacy/zstd_v04.c',
-        './legacy/zstd_v06.c',
-        './legacy/zstd_v07.c',
-        './legacy/zstd_v03.c',
-        './legacy/zstd_v02.c',
-        './legacy/zstd_v01.c',
-        './dictBuilder/cover.c',
-        './dictBuilder/divsufsort.c',
-        './dictBuilder/zdict.c',
-        './dictBuilder/fastcover.c',
+def get_sz3_plugin():
+    # SZ3 library and its hdf5 filter
+    sz3_dir = os.path.join("src", "SZ3")
+    include_dirs = [
+        os.path.join(sz3_dir, "include"),
+        os.path.join(sz3_dir, "include", "SZ3"),
+        os.path.join(sz3_dir, "include", "SZ3", "api"),
+        os.path.join(sz3_dir, "include", "SZ3", "compressor"),
+        os.path.join(sz3_dir, "include", "SZ3", "encoder"),
+        os.path.join(sz3_dir, "include", "SZ3", "frontend"),
+        os.path.join(sz3_dir, "include", "SZ3", "lossless"),
+        os.path.join(sz3_dir, "include", "SZ3", "predictor"),
+        os.path.join(sz3_dir, "include", "SZ3", "preprocessor"),
+        os.path.join(sz3_dir, "include", "SZ3", "quantizer"),
+        os.path.join(sz3_dir, "include", "SZ3", "utils"),
+        os.path.join(sz3_dir, "include", "SZ3", "utils", "inih"),
+        os.path.join(sz3_dir, "include", "SZ3", "utils", "ska_hash"),
     ]
+    # add version.hpp
+    include_dirs.append(os.path.join("src", "SZ3_extra"))
+    if sys.platform.startswith('darwin'):
+        # provide dummy omp.h
+        include_dirs.append(os.path.join("src", "SZ3_extra", "darwin"))
+    include_dirs.append("src/SZ3/tools/H5Z-SZ3/include")
 
-    ZSTD_EXTRA_OBJECTS = []
-    ZSTD_DEFINE_MACROS = []
-    ZSTD_SOURCES = []
-    ZSTD_INCLUDE_DIRS = [os.path.join(sz3_dir, "tools", "zstd")]
-    sz3_zstd_sources = []
-    for src in sz3_zstd_cmake_list:
-        items = src.split('/')
-        sz3_zstd_sources.append(os.path.join(sz3_dir, "tools", "zstd", items[1], items[2]))
-        ZSTD_INCLUDE_DIRS.append(os.path.join(sz3_dir, "tools", "zstd", items[1]))
-else:
-    ZSTD_EXTRA_OBJECTS = get_zstd_clib('extra_objects')
-    ZSTD_DEFINE_MACROS = get_zstd_clib('macros')
-    ZSTD_SOURCES = get_zstd_clib('sources')
-    ZSTD_INCLUDE_DIRS = get_zstd_clib('include_dirs')
-    sz3_zstd_sources = ZSTD_SOURCES
+    extra_compile_args = ['-std=c++14', '-O3', '-ffast-math', '-fopenmp']
+    extra_compile_args += ['/Ox', '/fp:fast', '/openmp']
+    extra_link_args = ['-fopenmp', '/openmp', "-lm"]
 
-sz3_extra_compile_args = ['-std=c++14', '-O3', '-ffast-math', '-fopenmp']
-sz3_extra_compile_args += ['/Ox', '/fp:fast', '/openmp']
-sz3_extra_link_args = ['-fopenmp', '/openmp', "-lm"]
-
-sz3_hdf5_plugin_source = os.path.join(sz3_hdf5_dir, "src", "H5Z_SZ3.cpp")
+    return HDF5PluginExtension(
+        "hdf5plugin.plugins.libh5sz3",
+        sources=["src/SZ3/tools/H5Z-SZ3/src/H5Z_SZ3.cpp"],
+        extra_objects=get_zstd_clib('extra_objects'),
+        depends=["src/SZ3/tools/H5Z-SZ3/include/H5Z_SZ3.hpp"],
+        include_dirs=include_dirs + get_zstd_clib('include_dirs'),
+        extra_compile_args=extra_compile_args,
+        extra_link_args=extra_link_args,
+        cpp11_required=True,
+    )
 
 
-sz3_plugin = HDF5PluginExtension(
-    "hdf5plugin.plugins.libh5sz3",
-    sources=[sz3_hdf5_plugin_source] + sz3_sources + ZSTD_SOURCES,
-    extra_objects=ZSTD_EXTRA_OBJECTS,
-    depends=[os.path.join(sz3_hdf5_dir, "include", "H5Z_SZ3.hpp")],
-    include_dirs=sz3_include_dirs + ZSTD_INCLUDE_DIRS + [os.path.join(sz3_hdf5_dir, "include")],
-    define_macros=ZSTD_DEFINE_MACROS,
-    extra_compile_args=sz3_extra_compile_args,
-    extra_link_args=sz3_extra_link_args,
-    cpp11_required=True,
-)
-
-if sys.platform.startswith('darwin'):
-    # this should be taken from the output of HDF5PluginExtension
-    ZSTD_INCLUDE_DIRS += [os.path.join('src', 'hdf5', 'include'), os.path.join('src', 'hdf5', 'include', 'darwin')]
-
-sz3_lib = ("sz3", {
-    "sources": sz3_zstd_sources,
-    "include_dirs": ZSTD_INCLUDE_DIRS,
-    # "cflags": ["-lzstd"],
-    # sse2=sse2_kwargs,
-    # avx2=avx2_kwargs,
-    # cpp11=cpp11_kwargs,
-})
-
-PLUGIN_LIB_DEPENDENCIES['sz3'] = ('sz3', 'zstd')
+PLUGIN_LIB_DEPENDENCIES['sz3'] = ('zstd',)
 
 
 def apply_filter_strip(libraries, extensions, dependencies):
@@ -1106,8 +1023,6 @@ library_list = [
     get_zlib_clib(),
     get_zstd_clib(),
 ]
-if not HDF5PLUGIN_ZSTD_FROM_BLOSC:
-    library_list.append(sz3_lib)
 libraries, extensions = apply_filter_strip(
     libraries=library_list,
     extensions=[
@@ -1119,7 +1034,7 @@ libraries, extensions = apply_filter_strip(
         get_h5zfp_plugin(),
         get_zstandard_plugin(),
         get_sz_plugin(),
-        sz3_plugin,
+        get_sz3_plugin(),
     ],
     dependencies=PLUGIN_LIB_DEPENDENCIES,
 )

--- a/setup.py
+++ b/setup.py
@@ -412,13 +412,14 @@ class BuildCLib(build_clib):
         for (lib_name, build_info) in libraries:
             cflags = list(build_info.get('cflags', []))
 
-            # Add flags from build config that corresponds to the compiler
+            # Add flags from build config
             config = self.distribution.get_command_obj("build").hdf5plugin_config
-            prefix = '/' if self.compiler.compiler_type == 'msvc' else '-'
-            cflags.extend(
-                [f for f in config.compile_args if f.startswith(prefix)])
+            cflags.extend(config.compile_args)
 
-            build_info['cflags'] = cflags
+            prefix = '/' if self.compiler.compiler_type == 'msvc' else '-'
+            build_info['cflags'] = [
+                f for f in cflags if f.startswith(prefix)
+            ]
 
             updated_libraries.append((lib_name, build_info))
 

--- a/setup.py
+++ b/setup.py
@@ -1043,13 +1043,13 @@ sz3_plugin = HDF5PluginExtension(
     "hdf5plugin.plugins.libh5sz3",
     sources=[sz3_hdf5_plugin_source] + sz3_sources + ZSTD_SOURCES,
     extra_objects=ZSTD_EXTRA_OBJECTS,
-    depends= [os.path.join(sz3_hdf5_dir, "include", "H5Z_SZ3.hpp")],
+    depends=[os.path.join(sz3_hdf5_dir, "include", "H5Z_SZ3.hpp")],
     include_dirs=sz3_include_dirs + ZSTD_INCLUDE_DIRS + [os.path.join(sz3_hdf5_dir, "include")],
     define_macros=ZSTD_DEFINE_MACROS,
     extra_compile_args=sz3_extra_compile_args,
     extra_link_args=sz3_extra_link_args,
     cpp11_required=True,
-    )
+)
 
 if sys.platform.startswith('darwin'):
     # this should be taken from the output of HDF5PluginExtension
@@ -1058,10 +1058,10 @@ if sys.platform.startswith('darwin'):
 sz3_lib = ("sz3", {
     "sources": sz3_zstd_sources,
     "include_dirs": ZSTD_INCLUDE_DIRS,
-    #"cflags": ["-lzstd"],
-    #sse2=sse2_kwargs,
-    #avx2=avx2_kwargs,
-    #cpp11=cpp11_kwargs,
+    # "cflags": ["-lzstd"],
+    # sse2=sse2_kwargs,
+    # avx2=avx2_kwargs,
+    # cpp11=cpp11_kwargs,
 })
 
 PLUGIN_LIB_DEPENDENCIES['sz3'] = ('sz3', 'zstd')
@@ -1096,6 +1096,7 @@ def apply_filter_strip(libraries, extensions, dependencies):
         if isinstance(ext, HDF5PluginExtension) and ext.hdf5_plugin_name not in stripped_filters
     ]
     return libraries, extensions
+
 
 library_list = [
     get_charls_clib(),

--- a/src/hdf5plugin/_filters.py
+++ b/src/hdf5plugin/_filters.py
@@ -523,7 +523,7 @@ class SZ3(_FilterRefClass):
 
     def __init__(self, absolute=None, relative=None, norm2=None, peak_signal_to_noise_ratio=None):
         n_nones = (absolute, relative, norm2, peak_signal_to_noise_ratio).count(None)
-        if  n_nones < 3:
+        if n_nones < 3:
             raise TypeError("hdf5plugin.SZ3() takes at most one not None argument")
         elif n_nones == 4:
             absolute = 0.0001
@@ -562,6 +562,7 @@ class SZ3(_FilterRefClass):
         high = struct.unpack('>I', packed[0:4])[0]  # Unpack most-significant bits as unsigned int
         low = struct.unpack('>I', packed[4:8])[0]  # Unpack least-significant bits as unsigned int
         return high, low
+
 
 class Zstd(_FilterRefClass):
     """``h5py.Group.create_dataset``'s compression arguments for using FciDecomp filter.

--- a/src/hdf5plugin/_utils.py
+++ b/src/hdf5plugin/_utils.py
@@ -124,16 +124,16 @@ def register_filter(name):
                 if not os.path.basename(filename).startswith('libh5blosc2'):
                     break  # That's the blosc(1) filename
             else:
-                _logger.error("Cannot initialize filter %s: File not found", name)
+                logger.error("Cannot initialize filter %s: File not found", name)
                 return False
         elif name == 'sz':  # Handle name prefix conflict with sz3
             for filename in filenames:
                 if not os.path.basename(filename).startswith('libh5sz3'):
                     break  # That's the sz filename
             else:
-                _logger.error("Cannot initialize filter %s: File not found", name)
+                logger.error("Cannot initialize filter %s: File not found", name)
                 return False
-        else:        
+        else:
             filename = filenames[0]
     else:
         logger.error(f"Cannot initialize filter {name}: File not found")

--- a/src/hdf5plugin/test.py
+++ b/src/hdf5plugin/test.py
@@ -233,7 +233,7 @@ class TestHDF5PluginRW(BaseTestHDF5PluginRW):
         """Write/read test with SZ3 filter plugin"""
         # TODO: Options mission
         tests = [{'lossless': False, 'absolute': 0.001},
-                 #{'lossless': False, 'relative': 0.0001},
+                 # {'lossless': False, 'relative': 0.0001},
                  ]
         for options in tests:
             for dtype in (numpy.float32, numpy.float64):


### PR DESCRIPTION
This PR aims at:
- making `setup.py` hopefully a bit easier to read by splitting the build config of static libs and plugins by using functions rather.
- building static library of compressors shared by multiple filters as well as the `hdf5_dl.c` file to avoid building multiple times the same code.

It also fixes some `flake8` linting issues, in particular a typo in `_utils.py` using `_logger` instead of `logger`.

closes #220 