### PR TITLE
Added check availability of C++14

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -59,6 +59,9 @@ Available options
    * - ``HDF5PLUGIN_CPP11``
      - Whether or not to compile C++11 code if available.
        Default: True if probed.
+   * - ``HDF5PLUGIN_CPP14``
+     - Whether or not to compile C++14 code if available.
+       Default: True if probed.
 
 Note: Boolean options are passed as ``True`` or ``False``.
 

--- a/setup.py
+++ b/setup.py
@@ -171,7 +171,7 @@ class HostConfig:
     def has_cpp11(self) -> bool:
         """Check C++11 availability on host"""
         if self.__compiler.compiler_type == 'msvc':
-            return sys.version_info[:2] >= (3, 5)
+            return True
         return check_compile_flags(self.__compiler, '-std=c++11', extension='.cc')
 
     def has_cpp14(self) -> bool:
@@ -198,7 +198,7 @@ class HostConfig:
             if not has_cpu_flag('avx2'):
                 return False  # AVX2 not available on host
             if self.__compiler.compiler_type == 'msvc':
-                return sys.version_info[:2] >= (3, 5)
+                return True
             return check_compile_flags(self.__compiler, '-mavx2')
         return False  # Disabled by default
 

--- a/setup.py
+++ b/setup.py
@@ -177,7 +177,7 @@ class HostConfig:
     def has_cpp14(self) -> bool:
         """Check C++14 availability on host"""
         if self.__compiler.compiler_type == 'msvc':
-            return True  # TODO check if correct
+            return True
         return check_compile_flags(self.__compiler, '-std=c++14', extension='.cc')
 
     def has_sse2(self) -> bool:

--- a/src/hdf5plugin/test.py
+++ b/src/hdf5plugin/test.py
@@ -299,6 +299,7 @@ class TestPackage(unittest.TestCase):
         self.assertIsInstance(config.build_config.sse2, bool)
         self.assertIsInstance(config.build_config.avx2, bool)
         self.assertIsInstance(config.build_config.cpp11, bool)
+        self.assertIsInstance(config.build_config.cpp14, bool)
         self.assertIsInstance(config.build_config.embedded_filters, tuple)
         self.assertIsInstance(config.registered_filters, dict)
 
@@ -310,6 +311,7 @@ class TestPackage(unittest.TestCase):
         self.assertIsInstance(config.sse2, bool)
         self.assertIsInstance(config.avx2, bool)
         self.assertIsInstance(config.cpp11, bool)
+        self.assertIsInstance(config.cpp14, bool)
         self.assertIsInstance(config.embedded_filters, tuple)
 
     def testVersion(self):


### PR DESCRIPTION
~~Merge PR #240 first!~~

This PR adds a check for C++14 availability as there was one for C++11 (https://github.com/silx-kit/hdf5plugin/commit/3afa9a448d0115247c3bedd1a38c3e454cddd5c9).
This follows the addition of the SZ3 filter.

It also cleans-up testing python version >=3.5 for available of MSVC compilation options since >=3.7 is required (https://github.com/silx-kit/hdf5plugin/commit/711ee768786361f8d81acdaa339bba6b9c427218).