### PR TITLE
Updated `bitshuffle` to v0.5.1; Added `HDF5PLUGIN_AVX512` configuration environment variable

### DIFF
--- a/doc/information.rst
+++ b/doc/information.rst
@@ -49,18 +49,18 @@ HDF5 filters and compression libraries
 
 HDF5 compression filters and compression libraries sources were obtained from:
 
-* **LZ4 plugin** (commit `d48f960 <https://github.com/nexusformat/HDF5-External-Filter-Plugins/tree/d48f96064cb6e229ede4bf5e5c0e1935cf691036>`_) and **lz4** (v1.9.3): https://github.com/nexusformat/HDF5-External-Filter-Plugins and https://github.com/Blosc/c-blosc/tree/9dc93b1de7c1ff6265d0ae554bd79077840849d8/internal-complibs/lz4-1.9.3
-* **bitshuffle plugin** (0.5.1) and **zstd** (v1.5.2): https://github.com/kiyo-masui/bitshuffle and https://github.com/Blosc/c-blosc/tree/9dc93b1de7c1ff6265d0ae554bd79077840849d8/internal-complibs/zstd-1.5.2
+* **LZ4 plugin** (commit `d48f960 <https://github.com/nexusformat/HDF5-External-Filter-Plugins/tree/d48f96064cb6e229ede4bf5e5c0e1935cf691036>`_) and **lz4** (v1.9.4): https://github.com/nexusformat/HDF5-External-Filter-Plugins and https://github.com/Blosc/c-blosc2/tree/v2.6.1/internal-complibs/lz4-1.9.4
+* **bitshuffle plugin** (0.5.1) and **zstd** (v1.5.2): https://github.com/kiyo-masui/bitshuffle, https://github.com/Blosc/c-blosc2/tree/v2.6.1/internal-complibs/lz4-1.9.4 and https://github.com/Blosc/c-blosc2/tree/v2.6.1/internal-complibs/zstd-1.5.2
 * **bzip2 plugin** (from PyTables v3.7.0) and **bzip2** (v1.0.8): https://github.com/PyTables/PyTables/, https://sourceware.org/git/bzip2.git
 * **hdf5-blosc plugin** (v1.0.0), **c-blosc** (v1.21.2) and **snappy** (v1.1.9): https://github.com/Blosc/hdf5-blosc, https://github.com/Blosc/c-blosc and https://github.com/google/snappy
 * **hdf5-blosc2 plugin** (from PyTables commit `8b8c7bc <https://github.com/PyTables/PyTables/commit/8b8c7bc7b1ff7f0a17bdd8b9f07198ab1bb4666d>`_), **c-blosc2** (`v2.6.1 <https://github.com/Blosc/c-blosc2/releases/tag/v2.6.1>`_): https://github.com/PyTables/PyTables/, https://github.com/Blosc/c-blosc2
 * **FCIDECOMP plugin** (v1.0.2) and **CharLS** (1.x branch, commit `25160a4 <https://github.com/team-charls/charls/tree/25160a42fb62e71e4b0ce081f5cb3f8bb73938b5>`_):
   ftp://ftp.eumetsat.int/pub/OPS/out/test-data/Test-data-for-External-Users/MTG_FCI_Test-Data/FCI_Decompression_Software_V1.0.2 and
   https://github.com/team-charls/charls
-* **SZ plugin** (commit `c25805c12b3 <https://github.com/szcompressor/SZ/commit/c25805c12b339d2cb2f406f95293b9a7313c4fb1>`_), `SZ <https://github.com/szcompressor/SZ>`_, `zlib <https://github.com/Blosc/c-blosc/tree/9dc93b1de7c1ff6265d0ae554bd79077840849d8/internal-complibs/zlib-1.2.11>`_ (v1.2.11) and `zstd <https://github.com/Blosc/c-blosc/tree/9dc93b1de7c1ff6265d0ae554bd79077840849d8/internal-complibs/zstd-1.5.2>`_ (v1.5.2)
-* **SZ3 plugin** (commit `4bbe9df7e4bcb <https://github.com/szcompressor/SZ3/commit/4bbe9df7e4bcb6ae6339fcb3033100da07fe7434>`_), `SZ3 <https://github.com/szcompressor/SZ3>`_ and `zstd <https://github.com/Blosc/c-blosc/tree/9dc93b1de7c1ff6265d0ae554bd79077840849d8/internal-complibs/zstd-1.5.2>`_ (v1.5.2)
+* **SZ plugin** (commit `c25805c12b3 <https://github.com/szcompressor/SZ/commit/c25805c12b339d2cb2f406f95293b9a7313c4fb1>`_), `SZ <https://github.com/szcompressor/SZ>`_, `zlib <https://github.com/Blosc/c-blosc/tree/9dc93b1de7c1ff6265d0ae554bd79077840849d8/internal-complibs/zlib-1.2.11>`_ (v1.2.11) and `zstd <https://github.com/Blosc/c-blosc2/tree/v2.6.1/internal-complibs/zstd-1.5.2>`_ (v1.5.2)
+* **SZ3 plugin** (commit `4bbe9df7e4bcb <https://github.com/szcompressor/SZ3/commit/4bbe9df7e4bcb6ae6339fcb3033100da07fe7434>`_), `SZ3 <https://github.com/szcompressor/SZ3>`_ and `zstd <https://github.com/Blosc/c-blosc2/tree/v2.6.1/internal-complibs/zstd-1.5.2>`_ (v1.5.2)
 * **HDF5-ZFP plugin** (commit `cd5422c <https://github.com/LLNL/H5Z-ZFP/tree/cd5422c146836e17c7a0380bfb05cf52d0c4467c>`_) and **zfp** (v1.0.0): https://github.com/LLNL/H5Z-ZFP and https://github.com/LLNL/zfp
-* **HDF5Plugin-Zstandard** (commit `d5afdb5 <https://github.com/aparamon/HDF5Plugin-Zstandard/tree/d5afdb5f04116d5c2d1a869dc9c7c0c72832b143>`_) and **zstd** (v1.5.2): https://github.com/aparamon/HDF5Plugin-Zstandard and https://github.com/Blosc/c-blosc/tree/9dc93b1de7c1ff6265d0ae554bd79077840849d8/internal-complibs/zstd-1.5.2
+* **HDF5Plugin-Zstandard** (commit `d5afdb5 <https://github.com/aparamon/HDF5Plugin-Zstandard/tree/d5afdb5f04116d5c2d1a869dc9c7c0c72832b143>`_) and **zstd** (v1.5.2): https://github.com/aparamon/HDF5Plugin-Zstandard and https://github.com/Blosc/c-blosc2/tree/v2.6.1/internal-complibs/zstd-1.5.2
 
 License
 -------

--- a/doc/information.rst
+++ b/doc/information.rst
@@ -50,7 +50,7 @@ HDF5 filters and compression libraries
 HDF5 compression filters and compression libraries sources were obtained from:
 
 * **LZ4 plugin** (commit `d48f960 <https://github.com/nexusformat/HDF5-External-Filter-Plugins/tree/d48f96064cb6e229ede4bf5e5c0e1935cf691036>`_) and **lz4** (v1.9.3): https://github.com/nexusformat/HDF5-External-Filter-Plugins and https://github.com/Blosc/c-blosc/tree/9dc93b1de7c1ff6265d0ae554bd79077840849d8/internal-complibs/lz4-1.9.3
-* **bitshuffle plugin** (0.4.2 + patch `PR #122 <https://github.com/kiyo-masui/bitshuffle/pull/122>`_) and **zstd** (v1.5.2): https://github.com/kiyo-masui/bitshuffle and https://github.com/Blosc/c-blosc/tree/9dc93b1de7c1ff6265d0ae554bd79077840849d8/internal-complibs/zstd-1.5.2
+* **bitshuffle plugin** (0.5.1) and **zstd** (v1.5.2): https://github.com/kiyo-masui/bitshuffle and https://github.com/Blosc/c-blosc/tree/9dc93b1de7c1ff6265d0ae554bd79077840849d8/internal-complibs/zstd-1.5.2
 * **bzip2 plugin** (from PyTables v3.7.0) and **bzip2** (v1.0.8): https://github.com/PyTables/PyTables/, https://sourceware.org/git/bzip2.git
 * **hdf5-blosc plugin** (v1.0.0), **c-blosc** (v1.21.2) and **snappy** (v1.1.9): https://github.com/Blosc/hdf5-blosc, https://github.com/Blosc/c-blosc and https://github.com/google/snappy
 * **hdf5-blosc2 plugin** (from PyTables commit `8b8c7bc <https://github.com/PyTables/PyTables/commit/8b8c7bc7b1ff7f0a17bdd8b9f07198ab1bb4666d>`_), **c-blosc2** (`v2.6.1 <https://github.com/Blosc/c-blosc2/releases/tag/v2.6.1>`_): https://github.com/PyTables/PyTables/, https://github.com/Blosc/c-blosc2

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -51,7 +51,12 @@ Available options
      - Whether or not to compile with `SSE2`_ support.
        Default: True on ppc64le and when probed on x86, False otherwise
    * - ``HDF5PLUGIN_AVX2``
-     - Whether or not to compile with `AVX2`_ support. avx2=True requires sse2=True.
+     - Whether or not to compile with `AVX2`_ support.
+       It requires enabling `SSE2`_ support.
+       Default: True on x86 when probed, False otherwise
+   * - ``HDF5PLUGIN_AVX512``
+     - Whether or not to compile with `AVX512`_ Foundation (F) and Byte and Word (BW) instruction sets support.
+       It requires enabling `SSE2`_ and `AVX2`_ support.
        Default: True on x86 when probed, False otherwise
    * - ``HDF5PLUGIN_BMI2``
      - Whether or not to compile Zstandard with `BMI2`_ support if available.
@@ -67,6 +72,7 @@ Note: Boolean options are passed as ``True`` or ``False``.
 
 
 .. _AVX2: https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#Advanced_Vector_Extensions_2
+.. _AVX512: https://en.wikipedia.org/wiki/AVX-512
 .. _BMI2: https://en.wikipedia.org/wiki/X86_Bit_manipulation_instruction_set
 .. _SSE2: https://en.wikipedia.org/wiki/SSE2
 .. _OpenMP: https://www.openmp.org/

--- a/setup.py
+++ b/setup.py
@@ -880,10 +880,6 @@ def get_bitshuffle_plugin():
     extra_compile_args = ['-O3', '-ffast-math', '-std=c99', '-fopenmp']
     extra_compile_args += ['/Ox', '/fp:fast', '/openmp']
     extra_link_args = ['-fopenmp', '/openmp']
-    if platform.machine() == "ppc64le":
-        sse2_options = {'extra_compile_args': ['-DUSESSE2']}
-    else:
-        sse2_options = {}
 
     return HDF5PluginExtension(
         "hdf5plugin.plugins.libh5bshuf",
@@ -899,7 +895,6 @@ def get_bitshuffle_plugin():
         define_macros=[("ZSTD_SUPPORT", 1)],
         extra_compile_args=extra_compile_args,
         extra_link_args=extra_link_args,
-        sse2=sse2_options,
     )
 
 

--- a/src/bitshuffle/.github/dependabot.yml
+++ b/src/bitshuffle/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/src/bitshuffle/.github/workflows/lint.yml
+++ b/src/bitshuffle/.github/workflows/lint.yml
@@ -12,10 +12,10 @@ jobs:
   lint-code:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 

--- a/src/bitshuffle/.github/workflows/main.yml
+++ b/src/bitshuffle/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install apt dependencies
       if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -33,7 +33,7 @@ jobs:
         brew install hdf5 pkg-config
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/src/bitshuffle/.github/workflows/wheels.yml
+++ b/src/bitshuffle/.github/workflows/wheels.yml
@@ -17,22 +17,26 @@ jobs:
 
     steps:
       # Checkout bitshuffle
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Build wheels for linux and x86 platforms
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.3.1
+        uses: pypa/cibuildwheel@v2.11.2
         with:
           output-dir: ./wheelhouse-hdf5-${{ matrix.hdf5}}
         env:
-          CIBW_SKIP: "pp* *musllinux*"
-          CIBW_ARCHS_LINUX: "x86_64"
+          CIBW_SKIP: "pp* *musllinux* cp311-macosx*"
+          CIBW_ARCHS: "x86_64"
           CIBW_BEFORE_ALL: |
             chmod +x .github/workflows/install_hdf5.sh
             .github/workflows/install_hdf5.sh ${{ matrix.hdf5 }}
             git submodule update --init
-          CIBW_ENVIRONMENT: |
-            LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib ENABLE_ZSTD=1
+          # Only build Haswell wheels on x86 for compatibility
+          CIBW_ENVIRONMENT: >
+            LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+            CPATH=/usr/local/include
+            ENABLE_ZSTD=1
+            BITSHUFFLE_ARCH=haswell
           CIBW_TEST_REQUIRES: pytest
           # Install different version of HDF5 for unit tests to ensure the
           # wheels are independent of HDF5 installation
@@ -41,9 +45,11 @@ jobs:
           #   .github/workflows/install_hdf5.sh 1.8.11
           # Run units tests but disable test_h5plugin.py
           CIBW_TEST_COMMAND: pytest {package}/tests
+          # The Github runners for macOS don't support AVX2 instructions and so the tests will fail with SIGILL, so skip them
+          CIBW_TEST_SKIP: "*macosx*"
 
       # Package wheels and host on CI
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse-hdf5-${{ matrix.hdf5 }}/*.whl
 
@@ -55,14 +61,14 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install apt dependencies
         run: |
           sudo apt-get install -y libhdf5-serial-dev hdf5-tools pkg-config
 
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -73,7 +79,7 @@ jobs:
       - name: Build sdist
         run: python setup.py sdist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
 
@@ -86,12 +92,12 @@ jobs:
     # Alternatively, to publish when a GitHub Release is created, use the following rule:
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.4.2
+      - uses: pypa/gh-action-pypi-publish@v1.5.1
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}

--- a/src/bitshuffle/README.rst
+++ b/src/bitshuffle/README.rst
@@ -17,7 +17,7 @@ except it operates at the bit level instead of the byte level. Arranging a
 typed data array in to a matrix with the elements as the rows and the bits
 within the elements as the columns, Bitshuffle "transposes" the matrix,
 such that all the least-significant-bits are in a row, etc.  This transpose
-is performed within blocks of data roughly 8kB long [1]_.
+is performed within blocks of data roughly 8 kB long [1]_.
 
 This does not in itself compress data, only rearranges it for more efficient
 compression. To perform the actual compression you will need a compression
@@ -97,20 +97,35 @@ Comparing Bitshuffle to other compression algorithms and HDF5 filters:
 Installation for Python
 -----------------------
 
-Installation requires python 2.7+ or 3.3+, HDF5 1.8.4 or later, HDF5 for python
-(h5py), Numpy and Cython. Bitshuffle is linked against HDF5. To use the dynamically 
-loaded HDF5 filter requires HDF5 1.8.11 or later. If ZSTD support is enabled the ZSTD 
-repo needs to pulled into bitshuffle before installation with::
+
+In most cases bitshuffle can be installed by `pip`::
+
+    pip install bitshuffle
+
+On Linux and macOS x86_64 platforms binary wheels are available, on other platforms a
+source build will be performed. The binary wheels are built with AVX2 support and will
+only run processors that support these instructions (most processors from 2015 onwards,
+i.e. Intel Haswell, AMD Excavator and later). On an unsupported processor these builds
+of bitshuffle will crash with `SIGILL`. To run on unsupported x86_64 processors, or
+target newer instructions such as AVX512, you should perform a build from source.
+This can be forced by giving pip the `--no-binary=bitshuffle` option.
+
+Source installation requires python 2.7+ or 3.3+, HDF5 1.8.4 or later, HDF5 for python
+(h5py), Numpy and Cython. Bitshuffle is linked against HDF5. To use the dynamically
+loaded HDF5 filter requires HDF5 1.8.11 or later.
+
+For total control, bitshuffle can be built using `python setup.py`. If ZSTD support is
+to be enabled the ZSTD repo needs to pulled into bitshuffle before installation with::
 
     git submodule update --init
 
-To install bitshuffle::
+To build and install bitshuffle::
 
     python setup.py install [--h5plugin [--h5plugin-dir=spam] --zstd]
 
-To get finer control of installation options, including whether to compile
-with OpenMP multi-threading, copy the ``setup.cfg.example`` to ``setup.cfg``
-and edit the values therein.
+To get finer control of installation options, including whether to compile with OpenMP
+multi-threading and the target microarchitecture copy the ``setup.cfg.example`` to
+``setup.cfg`` and edit the values therein.
 
 If using the dynamically loaded HDF5 filter (which gives you access to the
 Bitshuffle and LZF filters outside of python), set the environment variable
@@ -143,9 +158,9 @@ interface or through the convenience functions provided in
 version 2.5.0 and later Bitshuffle can be added to new datasets through the
 high level interface, as in the example below.
 
-The compression algorithm can be configured using the `filter_opts` in 
-`bitshuffle.h5.create_dataset()`. LZ4 is chosen with: 
-`(BLOCK_SIZE, h5.H5_COMPRESS_LZ4)` and ZSTD with: 
+The compression algorithm can be configured using the `filter_opts` in
+`bitshuffle.h5.create_dataset()`. LZ4 is chosen with:
+`(BLOCK_SIZE, h5.H5_COMPRESS_LZ4)` and ZSTD with:
 `(BLOCK_SIZE, h5.H5_COMPRESS_ZSTD, COMP_LVL)`. See `test_h5filter.py` for an example.
 
 Example h5py
@@ -213,6 +228,27 @@ Then, you use them like this::
 
 .. _`snappy-java`: https://github.com/xerial/snappy-java
 
+
+Rust HDF5 plugin
+----------------
+
+If you wish to open HDF5 files compressed with bitshuffle in your Rust program, there is a `Rust binding`_ for it.
+In your Cargo.toml::
+
+    [dependencies]
+    ...
+    hdf5-bitshuffle = "0.9"
+    ...
+
+To register the plugin in your code::
+
+    use hdf5_bitshuffle::register_bitshuffle_plugin;
+
+    fn main() {
+        register_bitshuffle_plugin();
+    }
+
+.. _`Rust binding`: https://docs.rs/hdf5-bitshuffle/latest/hdf5_bitshuffle/
 
 Anaconda
 --------

--- a/src/bitshuffle/bitshuffle/__init__.py
+++ b/src/bitshuffle/bitshuffle/__init__.py
@@ -8,6 +8,7 @@ Functions
     using_NEON
     using_SSE2
     using_AVX2
+    using_AVX512
     bitshuffle
     bitunshuffle
     compress_lz4
@@ -28,6 +29,7 @@ from bitshuffle.ext import (
     using_NEON,
     using_SSE2,
     using_AVX2,
+    using_AVX512,
     compress_lz4,
     decompress_lz4,
 )
@@ -49,6 +51,7 @@ __all__ = [
     "using_NEON",
     "using_SSE2",
     "using_AVX2",
+    "using_AVX512",
     "compress_lz4",
     "decompress_lz4",
 ] + zstd_api

--- a/src/bitshuffle/bitshuffle/ext.pyx
+++ b/src/bitshuffle/bitshuffle/ext.pyx
@@ -24,6 +24,7 @@ cdef extern from b"bitshuffle.h":
     int bshuf_using_NEON()
     int bshuf_using_SSE2()
     int bshuf_using_AVX2()
+    int bshuf_using_AVX512()
     int bshuf_bitshuffle(void *A, void *B, int size, int elem_size,
                          int block_size) nogil
     int bshuf_bitunshuffle(void *A, void *B, int size, int elem_size,
@@ -60,7 +61,9 @@ cdef extern int bshuf_trans_bit_byte_scal(void *A, void *B, int size, int elem_s
 cdef extern int bshuf_trans_bit_byte_SSE(void *A, void *B, int size, int elem_size)
 cdef extern int bshuf_trans_bit_byte_NEON(void *A, void *B, int size, int elem_size)
 cdef extern int bshuf_trans_bit_byte_AVX(void *A, void *B, int size, int elem_size)
+cdef extern int bshuf_trans_bit_byte_AVX512(void *A, void *B, int size, int elem_size)
 cdef extern int bshuf_trans_bitrow_eight(void *A, void *B, int size, int elem_size)
+cdef extern int bshuf_trans_bit_elem_AVX512(void *A, void *B, int size, int elem_size)
 cdef extern int bshuf_trans_bit_elem_AVX(void *A, void *B, int size, int elem_size)
 cdef extern int bshuf_trans_bit_elem_SSE(void *A, void *B, int size, int elem_size)
 cdef extern int bshuf_trans_bit_elem_NEON(void *A, void *B, int size, int elem_size)
@@ -73,9 +76,11 @@ cdef extern int bshuf_shuffle_bit_eightelem_scal(void *A, void *B, int size, int
 cdef extern int bshuf_shuffle_bit_eightelem_SSE(void *A, void *B, int size, int elem_size)
 cdef extern int bshuf_shuffle_bit_eightelem_NEON(void *A, void *B, int size, int elem_size)
 cdef extern int bshuf_shuffle_bit_eightelem_AVX(void *A, void *B, int size, int elem_size)
+cdef extern int bshuf_shuffle_bit_eightelem_AVX512(void *A, void *B, int size, int elem_size)
 cdef extern int bshuf_untrans_bit_elem_SSE(void *A, void *B, int size, int elem_size)
 cdef extern int bshuf_untrans_bit_elem_NEON(void *A, void *B, int size, int elem_size)
 cdef extern int bshuf_untrans_bit_elem_AVX(void *A, void *B, int size, int elem_size)
+cdef extern int bshuf_untrans_bit_elem_AVX512(void *A, void *B, int size, int elem_size)
 cdef extern int bshuf_untrans_bit_elem_scal(void *A, void *B, int size, int elem_size)
 cdef extern int bshuf_trans_bit_elem(void *A, void *B, int size, int elem_size)
 cdef extern int bshuf_untrans_bit_elem(void *A, void *B, int size, int elem_size)
@@ -103,6 +108,14 @@ def using_SSE2():
 def using_AVX2():
     """Whether compiled using AVX2 instructions."""
     if bshuf_using_AVX2():
+        return True
+    else:
+        return False
+
+
+def using_AVX512():
+    """Whether compiled using AVX512 instructions."""
+    if bshuf_using_AVX512():
         return True
     else:
         return False
@@ -188,8 +201,16 @@ def trans_bit_byte_AVX(np.ndarray arr not None):
     return _wrap_C_fun(&bshuf_trans_bit_byte_AVX, arr)
 
 
+def trans_bit_byte_AVX512(np.ndarray arr not None):
+    return _wrap_C_fun(&bshuf_trans_bit_byte_AVX512, arr)
+
+
 def trans_bitrow_eight(np.ndarray arr not None):
     return _wrap_C_fun(&bshuf_trans_bitrow_eight, arr)
+
+
+def trans_bit_elem_AVX512(np.ndarray arr not None):
+    return _wrap_C_fun(&bshuf_trans_bit_elem_AVX512, arr)
 
 
 def trans_bit_elem_AVX(np.ndarray arr not None):
@@ -240,6 +261,10 @@ def shuffle_bit_eightelem_AVX(np.ndarray arr not None):
     return _wrap_C_fun(&bshuf_shuffle_bit_eightelem_AVX, arr)
 
 
+def shuffle_bit_eightelem_AVX512(np.ndarray arr not None):
+    return _wrap_C_fun(&bshuf_shuffle_bit_eightelem_AVX512, arr)
+
+
 def untrans_bit_elem_SSE(np.ndarray arr not None):
     return _wrap_C_fun(&bshuf_untrans_bit_elem_SSE, arr)
 
@@ -250,6 +275,10 @@ def untrans_bit_elem_NEON(np.ndarray arr not None):
 
 def untrans_bit_elem_AVX(np.ndarray arr not None):
     return _wrap_C_fun(&bshuf_untrans_bit_elem_AVX, arr)
+
+
+def untrans_bit_elem_AVX512(np.ndarray arr not None):
+    return _wrap_C_fun(&bshuf_untrans_bit_elem_AVX512, arr)
 
 
 def untrans_bit_elem_scal(np.ndarray arr not None):

--- a/src/bitshuffle/setup.cfg.example
+++ b/src/bitshuffle/setup.cfg.example
@@ -4,7 +4,7 @@ h5plugin = 0
 h5plugin-dir = /usr/local/hdf5/lib/plugin
 
 [build_ext]
-# Whether to compile with OpenMP multi-threading. Default is system dependant:
+# Whether to compile with OpenMP multi-threading. Default is system dependent:
 # False on OSX (since the clang compiler does not yet support OpenMP) and True
 # otherwise.
 omp = 1

--- a/src/bitshuffle/src/bitshuffle_core.c
+++ b/src/bitshuffle/src/bitshuffle_core.c
@@ -16,6 +16,10 @@
 #include <string.h>
 
 
+#if defined(__AVX512F__) && defined (__AVX512BW__) && defined(__AVX2__) && defined(__SSE2__)
+#define USEAVX512
+#endif
+
 #if defined(__AVX2__) && defined (__SSE2__)
 #define USEAVX2
 #endif
@@ -78,6 +82,14 @@ int bshuf_using_AVX2(void) {
 #endif
 }
 
+
+int bshuf_using_AVX512(void) {
+#ifdef USEAVX512
+    return 1;
+#else
+    return 0;
+#endif
+}
 
 /* ---- Worker code not requiring special instruction sets. ----
  *
@@ -1384,7 +1396,6 @@ int64_t bshuf_shuffle_bit_eightelem_SSE(const void* in, void* out, const size_t 
  */
 
 #ifdef USEAVX2
-
 /* Transpose bits within bytes. */
 int64_t bshuf_trans_bit_byte_AVX(const void* in, void* out, const size_t size,
          const size_t elem_size) {
@@ -1625,6 +1636,162 @@ int64_t bshuf_untrans_bit_elem_AVX(const void* in, void* out, const size_t size,
 
 #endif // #ifdef USEAVX2
 
+#ifdef USEAVX512
+
+/* Transpose bits within bytes. */
+int64_t bshuf_trans_bit_byte_AVX512(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+
+    size_t ii, kk;
+    const char* in_b = (const char*) in;
+    char* out_b = (char*) out;
+    size_t nbyte = elem_size * size;
+    int64_t count;
+
+    int64_t* out_i64;
+    __m512i zmm;
+    __mmask64 bt;
+    if (nbyte >= 64) {
+        const __m512i mask = _mm512_set1_epi8(0);
+
+       for (ii = 0; ii + 63 < nbyte; ii += 64) {
+            zmm = _mm512_loadu_si512((__m512i *) &in_b[ii]);
+            for (kk = 0; kk < 8; kk++) {
+                bt = _mm512_cmp_epi8_mask(zmm, mask, 1);
+                zmm = _mm512_slli_epi16(zmm, 1);
+                out_i64 = (int64_t*) &out_b[((7 - kk) * nbyte + ii) / 8];
+                *out_i64 = (int64_t)bt;
+            }
+        }
+    }
+
+    __m256i ymm;
+    int32_t bt32;
+    int32_t* out_i32;
+    size_t start = nbyte - nbyte % 64;
+    for (ii = start; ii + 31 < nbyte; ii += 32) {
+        ymm = _mm256_loadu_si256((__m256i *) &in_b[ii]);
+        for (kk = 0; kk < 8; kk++) {
+            bt32 = _mm256_movemask_epi8(ymm);
+            ymm = _mm256_slli_epi16(ymm, 1);
+            out_i32 = (int32_t*) &out_b[((7 - kk) * nbyte + ii) / 8];
+            *out_i32 = bt32;
+        }
+    }
+
+
+    count = bshuf_trans_bit_byte_remainder(in, out, size, elem_size,
+            nbyte - nbyte % 64 % 32);
+
+    return count;
+}
+
+
+/* Transpose bits within elements. */
+int64_t bshuf_trans_bit_elem_AVX512(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+
+    int64_t count;
+
+    CHECK_MULT_EIGHT(size);
+
+    void* tmp_buf = malloc(size * elem_size);
+    if (tmp_buf == NULL) return -1;
+
+    count = bshuf_trans_byte_elem_SSE(in, out, size, elem_size);
+    CHECK_ERR_FREE(count, tmp_buf);
+    count = bshuf_trans_bit_byte_AVX512(out, tmp_buf, size, elem_size);
+    CHECK_ERR_FREE(count, tmp_buf);
+    count = bshuf_trans_bitrow_eight(tmp_buf, out, size, elem_size);
+
+    free(tmp_buf);
+
+    return count;
+
+}
+
+/* Shuffle bits within the bytes of eight element blocks. */
+int64_t bshuf_shuffle_bit_eightelem_AVX512(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+
+    CHECK_MULT_EIGHT(size);
+
+    // With a bit of care, this could be written such that such that it is
+    // in_buf = out_buf safe.
+    const char* in_b = (const char*) in;
+    char* out_b = (char*) out;
+
+    size_t ii, jj, kk;
+    size_t nbyte = elem_size * size;
+
+    __m512i zmm;
+    __mmask64 bt;
+
+    if (elem_size % 8) {
+        return bshuf_shuffle_bit_eightelem_AVX(in, out, size, elem_size);
+    } else {
+        const __m512i mask = _mm512_set1_epi8(0);
+        for (jj = 0; jj + 63 < 8 * elem_size; jj += 64) {
+            for (ii = 0; ii + 8 * elem_size - 1 < nbyte;
+                    ii += 8 * elem_size) {
+                zmm = _mm512_loadu_si512((__m512i *) &in_b[ii + jj]);
+                for (kk = 0; kk < 8; kk++) {
+                    bt = _mm512_cmp_epi8_mask(zmm, mask, 1);
+                    zmm = _mm512_slli_epi16(zmm, 1);
+                    size_t ind = (ii + jj / 8 + (7 - kk) * elem_size);
+                    * (int64_t *) &out_b[ind] = bt;
+                }
+            }
+        }
+
+    }
+    return size * elem_size;
+}
+
+/* Untranspose bits within elements. */
+int64_t bshuf_untrans_bit_elem_AVX512(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+
+    int64_t count;
+
+    CHECK_MULT_EIGHT(size);
+
+    void* tmp_buf = malloc(size * elem_size);
+    if (tmp_buf == NULL) return -1;
+
+    count = bshuf_trans_byte_bitrow_AVX(in, tmp_buf, size, elem_size);
+    CHECK_ERR_FREE(count, tmp_buf);
+    count =  bshuf_shuffle_bit_eightelem_AVX512(tmp_buf, out, size, elem_size);
+
+    free(tmp_buf);
+    return count;
+}
+
+#else // #ifdef USEAVX512
+
+int64_t bshuf_trans_bit_byte_AVX512(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+
+    return -14;
+}
+
+int64_t bshuf_trans_bit_elem_AVX512(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+    return -14;
+
+}
+
+int64_t bshuf_shuffle_bit_eightelem_AVX512(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+    return -14;
+}
+
+int64_t bshuf_untrans_bit_elem_AVX512(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+    return -14;
+}
+
+#endif
 
 /* ---- Drivers selecting best instruction set at compile time. ---- */
 
@@ -1632,7 +1799,9 @@ int64_t bshuf_trans_bit_elem(const void* in, void* out, const size_t size,
         const size_t elem_size) {
 
     int64_t count;
-#ifdef USEAVX2
+#ifdef USEAVX512
+    count = bshuf_trans_bit_elem_AVX512(in, out, size, elem_size);
+#elif defined USEAVX2
     count = bshuf_trans_bit_elem_AVX(in, out, size, elem_size);
 #elif defined(USESSE2)
     count = bshuf_trans_bit_elem_SSE(in, out, size, elem_size);
@@ -1649,7 +1818,9 @@ int64_t bshuf_untrans_bit_elem(const void* in, void* out, const size_t size,
         const size_t elem_size) {
 
     int64_t count;
-#ifdef USEAVX2
+#ifdef USEAVX512
+    count = bshuf_untrans_bit_elem_AVX512(in, out, size, elem_size);
+#elif defined USEAVX2
     count = bshuf_untrans_bit_elem_AVX(in, out, size, elem_size);
 #elif defined(USESSE2)
     count = bshuf_untrans_bit_elem_SSE(in, out, size, elem_size);

--- a/src/bitshuffle/src/bitshuffle_core.h
+++ b/src/bitshuffle/src/bitshuffle_core.h
@@ -19,6 +19,7 @@
  *      -11   : Missing SSE.
  *      -12   : Missing AVX.
  *      -13   : Missing Arm Neon.
+ *      -14   : Missing AVX512.
  *      -80   : Input size not a multiple of 8.
  *      -81   : block_size not multiple of 8.
  *      -91   : Decompression error, wrong number of bytes processed.
@@ -89,6 +90,18 @@ int bshuf_using_NEON(void);
  *
  */
 int bshuf_using_AVX2(void);
+
+
+/* ---- bshuf_using_AVX512 ----
+ *
+ * Whether routines where compiled with the AVX512 instruction set.
+ *
+ * Returns
+ * -------
+ *  1 if using AVX512, 0 otherwise.
+ *
+ */
+int bshuf_using_AVX512(void);
 
 
 /* ---- bshuf_default_block_size ----

--- a/src/bitshuffle/src/bshuf_h5filter.c
+++ b/src/bitshuffle/src/bshuf_h5filter.c
@@ -25,7 +25,7 @@ void bshuf_write_uint32_BE(void* buf, uint32_t num);
 uint32_t bshuf_read_uint32_BE(const void* buf);
 
 
-// Only called on compresion, not on reverse.
+// Only called on compression, not on reverse.
 herr_t bshuf_h5_set_local(hid_t dcpl, hid_t type, hid_t space){
 
     herr_t r;
@@ -192,7 +192,7 @@ size_t bshuf_h5_filter(unsigned int flags, size_t cd_nelmts,
             // Bit shuffle/compress.
             // Write the header, described in
             // http://www.hdfgroup.org/services/filters/HDF5_LZ4.pdf.
-            // Techincally we should be using signed integers instead of
+            // Technically we should be using signed integers instead of
             // unsigned ones, however for valid inputs (positive numbers) these
             // have the same representation.
             bshuf_write_uint64_BE(out_buf, nbytes_uncomp);

--- a/src/bitshuffle/src/bshuf_h5filter.h
+++ b/src/bitshuffle/src/bshuf_h5filter.h
@@ -13,7 +13,7 @@
  *
  * Filter Options
  * --------------
- *  block_size (option slot 0) : interger (optional)
+ *  block_size (option slot 0) : integer (optional)
  *      What block size to use (in elements not bytes). Default is 0,
  *      for which bitshuffle will pick a block size with a target of 8kb.
  *  Compression (option slot 1) : 0 or BSHUF_H5_COMPRESS_LZ4

--- a/src/bitshuffle/src/iochain.c
+++ b/src/bitshuffle/src/iochain.c
@@ -1,5 +1,5 @@
 /*
- * IOchain - Distribute a chain of dependant IO events amoung threads.
+ * IOchain - Distribute a chain of dependent IO events among threads.
  *
  * This file is part of Bitshuffle
  * Author: Kiyoshi Masui <kiyo@physics.ubc.ca>

--- a/src/bitshuffle/src/iochain.h
+++ b/src/bitshuffle/src/iochain.h
@@ -1,5 +1,5 @@
 /*
- * IOchain - Distribute a chain of dependant IO events amoung threads.
+ * IOchain - Distribute a chain of dependent IO events among threads.
  *
  * This file is part of Bitshuffle
  * Author: Kiyoshi Masui <kiyo@physics.ubc.ca>

--- a/src/bitshuffle/tests/make_regression_tdata.py
+++ b/src/bitshuffle/tests/make_regression_tdata.py
@@ -24,7 +24,7 @@ OUT_FILE = "tests/data/regression_%s.h5" % bitshuffle.__version__
 DTYPES = ["a1", "a2", "a3", "a4", "a6", "a8", "a10"]
 
 f = h5py.File(OUT_FILE, "w")
-g_orig = f.create_group("origional")
+g_orig = f.create_group("original")
 g_comp_lz4 = f.create_group("compressed")
 g_comp_zstd = f.create_group("compressed_zstd")
 

--- a/src/bitshuffle/tests/test_ext.py
+++ b/src/bitshuffle/tests/test_ext.py
@@ -34,7 +34,7 @@ class TestProfile(unittest.TestCase):
         if TIME:
             n *= TIME
         # Almost random bits, but now quite. All bits exercised (to fully test
-        # transpose) but still slightly compresible.
+        # transpose) but still slightly compressible.
         self.data = random.randint(0, 200, n).astype(np.uint8)
         self.fun = ext.copy
         self.check = None
@@ -57,6 +57,8 @@ class TestProfile(unittest.TestCase):
             if len(err.args) > 1 and (err.args[1] == -11) and not ext.using_SSE2():
                 return
             if len(err.args) > 1 and (err.args[1] == -12) and not ext.using_AVX2():
+                return
+            if len(err.args) > 1 and (err.args[1] == -14) and not ext.using_AVX512():
                 return
             else:
                 raise
@@ -171,6 +173,18 @@ class TestProfile(unittest.TestCase):
         self.fun = ext.trans_bit_byte_AVX
         self.check = trans_bit_byte
 
+    def test_03h_trans_bit_byte_AVX512(self):
+        self.case = "bit T byte AVX512 64"
+        self.data = self.data.view(np.float64)
+        self.fun = ext.trans_bit_byte_AVX512
+        self.check = trans_bit_byte
+
+    def test_03g_trans_bit_byte_AVX512_32(self):
+        self.case = "bit T byte AVX512 32"
+        self.data = self.data.view(np.float32)
+        self.fun = ext.trans_bit_byte_AVX512
+        self.check = trans_bit_byte
+
     def test_04a_trans_bit_elem_AVX(self):
         self.case = "bit T elem AVX 64"
         self.data = self.data.view(np.float64)
@@ -211,6 +225,30 @@ class TestProfile(unittest.TestCase):
         self.case = "bit T elem SSE 64"
         self.data = self.data.view(np.float64)
         self.fun = ext.trans_bit_elem_SSE
+        self.check = trans_bit_elem
+
+    def test_04h_trans_bit_elem_AVX512(self):
+        self.case = "bit T elem AVX512 64"
+        self.data = self.data.view(np.float64)
+        self.fun = ext.trans_bit_elem_AVX512
+        self.check = trans_bit_elem
+
+    def test_04i_trans_bit_elem_AVX512(self):
+        self.case = "bit T elem AVX 128"
+        self.data = self.data.view(np.complex128)
+        self.fun = ext.trans_bit_elem_AVX512
+        self.check = trans_bit_elem
+
+    def test_04j_trans_bit_elem_AVX512_32(self):
+        self.case = "bit T elem AVX512 32"
+        self.data = self.data.view(np.float32)
+        self.fun = ext.trans_bit_elem_AVX512
+        self.check = trans_bit_elem
+
+    def test_04k_trans_bit_elem_AVX512_16(self):
+        self.case = "bit T elem AVX512 16"
+        self.data = self.data.view(np.int16)
+        self.fun = ext.trans_bit_elem_AVX512
         self.check = trans_bit_elem
 
     def test_06a_untrans_bit_elem_16(self):
@@ -260,6 +298,20 @@ class TestProfile(unittest.TestCase):
         pre_trans = self.data.view(np.float64)
         self.data = trans_bit_elem(pre_trans)
         self.fun = ext.untrans_bit_elem_scal
+        self.check_data = pre_trans
+
+    def test_06h_untrans_bit_elem_32(self):
+        self.case = "bit U elem AVX512 32"
+        pre_trans = self.data.view(np.float32)
+        self.data = trans_bit_elem(pre_trans)
+        self.fun = ext.untrans_bit_elem_AVX512
+        self.check_data = pre_trans
+
+    def test_06i_untrans_bit_elem_64(self):
+        self.case = "bit U elem AVX512 64"
+        pre_trans = self.data.view(np.float64)
+        self.data = trans_bit_elem(pre_trans)
+        self.fun = ext.untrans_bit_elem_AVX512
         self.check_data = pre_trans
 
     def test_07a_trans_byte_bitrow_64(self):
@@ -314,6 +366,30 @@ class TestProfile(unittest.TestCase):
         self.fun = ext.shuffle_bit_eightelem_AVX
         self.check = ext.shuffle_bit_eightelem_scal
 
+    def test_08g_shuffle_bit_eight_AVX512_32(self):
+        self.case = "bit S eight AVX 32"
+        self.data = self.data.view(np.float32)
+        self.fun = ext.shuffle_bit_eightelem_AVX512
+        self.check = ext.shuffle_bit_eightelem_scal
+
+    def test_08h_shuffle_bit_eight_AVX512_64(self):
+        self.case = "bit S eight AVX512 64"
+        self.data = self.data.view(np.float64)
+        self.fun = ext.shuffle_bit_eightelem_AVX512
+        self.check = ext.shuffle_bit_eightelem_scal
+
+    def test_08i_shuffle_bit_eight_AVX512_16(self):
+        self.case = "bit S eight AVX512 16"
+        self.data = self.data.view(np.int16)
+        self.fun = ext.shuffle_bit_eightelem_AVX512
+        self.check = ext.shuffle_bit_eightelem_scal
+
+    def test_08i_shuffle_bit_eight_AVX512_128(self):
+        self.case = "bit S eight AVX512 128"
+        self.data = self.data.view(np.complex128)
+        self.fun = ext.shuffle_bit_eightelem_AVX512
+        self.check = ext.shuffle_bit_eightelem_scal
+
     def test_09a_trans_bit_elem_scal_64(self):
         self.case = "bit T elem scal 64"
         self.data = self.data.view(np.float64)
@@ -351,6 +427,13 @@ class TestProfile(unittest.TestCase):
         pre_trans = self.data.view(np.float64)
         self.data = trans_bit_elem(pre_trans)
         self.fun = ext.untrans_bit_elem_AVX
+        self.check_data = pre_trans
+
+    def test_09g_untrans_bit_elem_AVX_64(self):
+        self.case = "bit U elem AVX512 64"
+        pre_trans = self.data.view(np.float64)
+        self.data = trans_bit_elem(pre_trans)
+        self.fun = ext.untrans_bit_elem_AVX512
         self.check_data = pre_trans
 
     def test_10a_bitshuffle_64(self):
@@ -481,7 +564,15 @@ class TestOddLengths(unittest.TestCase):
         self.fun = ext.trans_bit_elem_AVX
         self.check = trans_bit_elem
 
+    def test_trans_bit_elem_AVX512(self):
+        self.fun = ext.trans_bit_elem_AVX512
+        self.check = trans_bit_elem
+
     def test_untrans_bit_elem_AVX(self):
+        self.fun = lambda x: ext.untrans_bit_elem_SSE(ext.trans_bit_elem(x))
+        self.check = lambda x: x
+
+    def test_untrans_bit_elem_AVX512(self):
         self.fun = lambda x: ext.untrans_bit_elem_SSE(ext.trans_bit_elem(x))
         self.check = lambda x: x
 
@@ -515,12 +606,14 @@ class TestOddLengths(unittest.TestCase):
                 return
             if len(err.args) > 1 and (err.args[1] == -12) and not ext.using_AVX2():
                 return
+            if len(err.args) > 1 and (err.args[1] == -14) and not ext.using_AVX512():
+                return
             else:
                 raise
 
 
 class TestBitShuffleCircle(unittest.TestCase):
-    """Ensure that final filter is circularly consistant for any data type and
+    """Ensure that final filter is circularly consistent for any data type and
     any length buffer."""
 
     def test_circle(self):


### PR DESCRIPTION
This PR:
- Adds support for enable AVX512 "Foundation" and "Byte and Word" instruction sets. This can be configured through the `HDF5PLUGIN_AVX512` env. var. Else it is probed with `cpuinfo` and checking compile flag availability.
- Updates the version of `bitshuffle` embedded to v0.5.1. This version uses AVX512 F and BW.
- Updates the links of lz4 and zstd as a follow-up of #250 

closes #236