### PR TITLE
Fixed `blosc2`: Added patch from c-blosc2 PR #436

### DIFF
--- a/doc/information.rst
+++ b/doc/information.rst
@@ -53,7 +53,7 @@ HDF5 compression filters and compression libraries sources were obtained from:
 * **bitshuffle plugin** (0.5.1) and **zstd** (v1.5.2): https://github.com/kiyo-masui/bitshuffle, https://github.com/Blosc/c-blosc2/tree/v2.6.1/internal-complibs/lz4-1.9.4 and https://github.com/Blosc/c-blosc2/tree/v2.6.1/internal-complibs/zstd-1.5.2
 * **bzip2 plugin** (from PyTables v3.7.0) and **bzip2** (v1.0.8): https://github.com/PyTables/PyTables/, https://sourceware.org/git/bzip2.git
 * **hdf5-blosc plugin** (v1.0.0), **c-blosc** (v1.21.2) and **snappy** (v1.1.9): https://github.com/Blosc/hdf5-blosc, https://github.com/Blosc/c-blosc and https://github.com/google/snappy
-* **hdf5-blosc2 plugin** (from PyTables commit `8b8c7bc <https://github.com/PyTables/PyTables/commit/8b8c7bc7b1ff7f0a17bdd8b9f07198ab1bb4666d>`_), **c-blosc2** (`v2.6.1 <https://github.com/Blosc/c-blosc2/releases/tag/v2.6.1>`_): https://github.com/PyTables/PyTables/, https://github.com/Blosc/c-blosc2
+* **hdf5-blosc2 plugin** (from PyTables commit `8b8c7bc <https://github.com/PyTables/PyTables/commit/8b8c7bc7b1ff7f0a17bdd8b9f07198ab1bb4666d>`_), **c-blosc2** (`v2.6.1 <https://github.com/Blosc/c-blosc2/releases/tag/v2.6.1>`_ + `patch <https://github.com/Blosc/c-blosc2/pull/436>`_): https://github.com/PyTables/PyTables/, https://github.com/Blosc/c-blosc2
 * **FCIDECOMP plugin** (v1.0.2) and **CharLS** (1.x branch, commit `25160a4 <https://github.com/team-charls/charls/tree/25160a42fb62e71e4b0ce081f5cb3f8bb73938b5>`_):
   ftp://ftp.eumetsat.int/pub/OPS/out/test-data/Test-data-for-External-Users/MTG_FCI_Test-Data/FCI_Decompression_Software_V1.0.2 and
   https://github.com/team-charls/charls

--- a/src/c-blosc2/blosc/CMakeLists.txt
+++ b/src/c-blosc2/blosc/CMakeLists.txt
@@ -172,11 +172,17 @@ if(COMPILER_SUPPORT_SSE2)
             set_source_files_properties(
                     shuffle-sse2.c bitshuffle-sse2.c blosclz.c fastcopy.c
                     PROPERTIES COMPILE_FLAGS "/arch:SSE2")
+            set_property(
+                    SOURCE shuffle.c
+                    APPEND PROPERTY COMPILE_OPTIONS "/arch:SSE2")
         endif()
     else()
         set_source_files_properties(
                 shuffle-sse2.c bitshuffle-sse2.c blosclz.c fastcopy.c
                 PROPERTIES COMPILE_FLAGS -msse2)
+        set_property(
+                SOURCE shuffle.c
+                APPEND PROPERTY COMPILE_OPTIONS -msse2)
     endif()
 
     # Define a symbol for the shuffle-dispatch implementation
@@ -191,10 +197,16 @@ if(COMPILER_SUPPORT_AVX2)
         set_source_files_properties(
                 shuffle-avx2.c bitshuffle-avx2.c
                 PROPERTIES COMPILE_FLAGS "/arch:AVX2")
+        set_property(
+                SOURCE shuffle.c
+                APPEND PROPERTY COMPILE_OPTIONS "/arch:AVX2")
     else()
         set_source_files_properties(
                 shuffle-avx2.c bitshuffle-avx2.c
                 PROPERTIES COMPILE_FLAGS -mavx2)
+        set_property(
+                SOURCE shuffle.c
+                APPEND PROPERTY COMPILE_OPTIONS -mavx2)
     endif()
 
     # Define a symbol for the shuffle-dispatch implementation
@@ -208,11 +220,17 @@ if(COMPILER_SUPPORT_NEON)
     set_source_files_properties(
             shuffle-neon.c bitshuffle-neon.c
             PROPERTIES COMPILE_FLAGS "-flax-vector-conversions")
+    set_property(
+            SOURCE shuffle.c
+            APPEND PROPERTY COMPILE_OPTIONS "-flax-vector-conversions")
     if(CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l)
         # Only armv7l needs special -mfpu=neon flag; aarch64 doesn't.
       set_source_files_properties(
             shuffle-neon.c bitshuffle-neon.c
             PROPERTIES COMPILE_FLAGS "-mfpu=neon -flax-vector-conversions")
+      set_property(
+            SOURCE shuffle.c
+            APPEND PROPERTY COMPILE_OPTIONS "-mfpu=neon -flax-vector-conversions")
     endif()
     # Define a symbol for the shuffle-dispatch implementation
     # so it knows NEON is supported even though that file is
@@ -222,8 +240,12 @@ if(COMPILER_SUPPORT_NEON)
             APPEND PROPERTY COMPILE_DEFINITIONS SHUFFLE_NEON_ENABLED)
 endif()
 if(COMPILER_SUPPORT_ALTIVEC)
-    set_source_files_properties(shuffle-altivec.c bitshuffle-altivec.c
+    set_source_files_properties(
+            shuffle-altivec.c bitshuffle-altivec.c
             PROPERTIES COMPILE_FLAGS -DNO_WARN_X86_INTRINSICS)
+    set_property(
+            SOURCE shuffle.c
+            APPEND PROPERTY COMPILE_OPTIONS -DNO_WARN_X86_INTRINSICS)
 
     # Define a symbol for the shuffle-dispatch implementation
     # so it knows ALTIVEC is supported even though that file is

--- a/src/c-blosc2/blosc/shuffle.c
+++ b/src/c-blosc2/blosc/shuffle.c
@@ -141,7 +141,7 @@ __cpuidex(int32_t cpuInfo[4], int32_t function_id, int32_t subfunction_id) {
 
 // GCC folks added _xgetbv in immintrin.h starting in GCC 9
 // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71659
-#if defined(__i386__) && !(defined(_IMMINTRIN_H_INCLUDED) && (BLOSC_GCC_VERSION >= 900))
+#if !(defined(_IMMINTRIN_H_INCLUDED) && (BLOSC_GCC_VERSION >= 900)) && !defined(__IMMINTRIN_H)
 /* Reads the content of an extended control register.
    https://software.intel.com/en-us/articles/how-to-detect-new-instruction-support-in-the-4th-generation-intel-core-processor-family
 */
@@ -160,7 +160,7 @@ _xgetbv(uint32_t xcr) {
     );
   return ((uint64_t)edx << 32) | eax;
 }
-#endif  // defined(__i386__) && !(defined(_IMMINTRIN_H_INCLUDED) && (BLOSC_GCC_VERSION >= 900))
+#endif  // !(defined(_IMMINTRIN_H_INCLUDED) && (BLOSC_GCC_VERSION >= 900)) && !defined(__IMMINTRIN_H)
 #endif /* defined(_MSC_VER) */
 
 #ifndef _XCR_XFEATURE_ENABLED_MASK
@@ -204,7 +204,7 @@ static blosc_cpu_features blosc_get_cpu_features(void) {
   bool ymm_state_enabled = false;
   //bool zmm_state_enabled = false;  // commented this out for avoiding an 'unused variable' warning
 
-#if defined(__i386__) && defined(_XCR_XFEATURE_ENABLED_MASK)
+#if defined(_XCR_XFEATURE_ENABLED_MASK)
   if (xsave_available && xsave_enabled_by_os && (
       sse2_available || sse3_available || ssse3_available
       || sse41_available || sse42_available
@@ -219,7 +219,7 @@ static blosc_cpu_features blosc_get_cpu_features(void) {
         restored as well as all of zmm16-zmm31 and the opmask registers. */
     //zmm_state_enabled = (xcr0_contents & 0x70) == 0x70;
   }
-#endif /* defined(__i386__) && defined(_XCR_XFEATURE_ENABLED_MASK) */
+#endif /* defined(_XCR_XFEATURE_ENABLED_MASK) */
 
 #if defined(BLOSC_DUMP_CPU_INFO)
   printf("Shuffle CPU Information:\n");


### PR DESCRIPTION
This PR applies a patch to `c-blosc2` to fix an issue with selecting the right implementation depending on available SIMD.

See https://github.com/Blosc/c-blosc2/pull/436