### PR TITLE
Enabled ARM Neon support for `blosc2`; Updated `blosc` and `blosc2` build configuration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -754,24 +754,12 @@ def get_blosc_plugin():
     hdf5_blosc_dir = 'src/hdf5-blosc/src'
 
     # blosc sources
-    sources = [f for f in glob(f'{blosc_dir}/*.c')
-               if 'avx2' not in f and 'sse2' not in f]
+    sources = glob(f'{blosc_dir}/*.c')
     include_dirs = ['src/c-blosc', blosc_dir]
-    define_macros = []
-
-    if platform.machine() == 'ppc64le':
-        # SSE2 support in blosc uses x86 assembly code in shuffle
-        sse2_kwargs = {}
-    else:
-        sse2_kwargs = {
-            'sources': glob(f'{blosc_dir}/*-sse2.c'),
-            'define_macros': [('SHUFFLE_SSE2_ENABLED', 1)],
-        }
-
-    avx2_kwargs = {
-        'sources': glob(f'{blosc_dir}/*-avx2.c'),
-        'define_macros': [('SHUFFLE_AVX2_ENABLED', 1)],
-    }
+    define_macros = [
+        ('SHUFFLE_SSE2_ENABLED', 1),
+        ('SHUFFLE_AVX2_ENABLED', 1),
+    ]
 
     # compression libs
     # lz4
@@ -808,8 +796,6 @@ def get_blosc_plugin():
         define_macros=define_macros,
         extra_compile_args=extra_compile_args,
         extra_link_args=extra_link_args,
-        sse2=sse2_kwargs,
-        avx2=avx2_kwargs,
         cpp11=cpp11_kwargs,
     )
 

--- a/setup.py
+++ b/setup.py
@@ -826,26 +826,14 @@ def get_blosc2_plugin():
     blosc2_dir = 'src/c-blosc2'
 
     # blosc sources
-    sources = [f for f in glob(f'{blosc2_dir}/blosc/*.c')
-            if 'avx2' not in f and 'sse2' not in f and 'altivec' not in f and 'neon' not in f]
+    sources = glob(f'{blosc2_dir}/blosc/*.c')
     include_dirs = [blosc2_dir, f'{blosc2_dir}/blosc', f'{blosc2_dir}/include']
-    define_macros = []
-
-    # TODO enable neon
-    sse2_kwargs = {
-        'sources': glob(f'{blosc2_dir}/blosc/*-sse2.c'),
-        'define_macros': [('SHUFFLE_SSE2_ENABLED', 1)],
-        }
-
-    avx2_kwargs = {
-        'sources': glob(f'{blosc2_dir}/blosc/*-avx2.c'),
-        'define_macros': [('SHUFFLE_AVX2_ENABLED', 1)],
-        }
-
-    if platform.machine() == "ppc64le":  # altivec
-        sources += glob(f'{blosc2_dir}/blosc/*-altivec.c')
-        define_macros += [('SHUFFLE_ALTIVEC_ENABLED', 1)]
-
+    define_macros = [
+        ('SHUFFLE_SSE2_ENABLED', 1),
+        ('SHUFFLE_AVX2_ENABLED', 1),
+        ('SHUFFLE_NEON_ENABLED', 1),
+        ('SHUFFLE_ALTIVEC_ENABLED', 1),
+    ]
 
     # compression libs
     # lz4
@@ -875,9 +863,7 @@ def get_blosc2_plugin():
         define_macros=define_macros,
         extra_compile_args=extra_compile_args,
         extra_link_args=extra_link_args,
-        sse2=sse2_kwargs,
-        avx2=avx2_kwargs,
-        )
+    )
 
 
 PLUGIN_LIB_DEPENDENCIES['blosc2'] = 'lz4', 'zlib', 'zstd'

--- a/setup.py
+++ b/setup.py
@@ -533,14 +533,6 @@ class PluginBuildExt(build_ext):
                     for name, value in e.cpp11.items():
                         attribute = getattr(e, name)
                         attribute += value
-                if config.use_sse2:
-                    for name, value in e.sse2.items():
-                        attribute = getattr(e, name)
-                        attribute += value
-                if config.use_avx2:
-                    for name, value in e.avx2.items():
-                        attribute = getattr(e, name)
-                        attribute += value
 
             if not config.use_openmp:  # Remove OpenMP flags
                 e.extra_compile_args = [
@@ -561,7 +553,7 @@ class PluginBuildExt(build_ext):
 class HDF5PluginExtension(Extension):
     """Extension adding specific things to build a HDF5 plugin"""
 
-    def __init__(self, name, sse2=None, avx2=None, cpp11=None, cpp11_required=False, **kwargs):
+    def __init__(self, name, cpp11=None, cpp11_required=False, **kwargs):
         Extension.__init__(self, name, **kwargs)
 
         if not self.depends:
@@ -580,8 +572,6 @@ class HDF5PluginExtension(Extension):
 
         self.define_macros.append(('H5_USE_18_API', None))
 
-        self.sse2 = sse2 if sse2 is not None else {}
-        self.avx2 = avx2 if avx2 is not None else {}
         self.cpp11 = cpp11 if cpp11 is not None else {}
         self.cpp11_required = cpp11_required
 


### PR DESCRIPTION
This PR enables Neon support for `blosc2` with ARM.
On macOS (at least) no compilation flag needs to be passed for enabling Neon.

This PR also simplifies the build of `blosc` and `blosc2` since now architecture specific source files compiles even on wrong architecture, thanks to e.g., `#if defined(__ARM_NEON) .. #endif` (this was need for supporting `universal2` build).

Full test matrix of this PR is available here: https://gitlab.esrf.fr/silx/bob/hdf5plugin/-/pipelines/100336

closes #244