### PR TITLE
Updated documentation

### DIFF
--- a/doc/information.rst
+++ b/doc/information.rst
@@ -53,11 +53,11 @@ HDF5 compression filters and compression libraries sources were obtained from:
   (commit `d48f960 <https://github.com/nexusformat/HDF5-External-Filter-Plugins/tree/d48f96064cb6e229ede4bf5e5c0e1935cf691036>`_)
   using LZ4.
 * `bitshuffle plugin <https://github.com/kiyo-masui/bitshuffle>`_ (v0.5.1) using LZ4 and ZStd.
-* bzip2 plugin (from `PyTables <https://github.com/PyTables/PyTables/>`_ v3.7.0)
+* bzip2 plugin (from `PyTables <https://github.com/PyTables/PyTables/>`_ v3.8.0)
   using `BZip2 <https://sourceware.org/git/bzip2.git>`_ (v1.0.8).
 * `hdf5-blosc plugin <https://github.com/Blosc/hdf5-blosc>`_ (v1.0.0)
   using `c-blosc <https://github.com/Blosc/c-blosc>`_ (v1.21.2), LZ4, Snappy, ZLib and ZStd.
-* hdf5-blosc2 plugin (from `PyTables <https://github.com/PyTables/PyTables/>`_ commit `8b8c7bc <https://github.com/PyTables/PyTables/commit/8b8c7bc7b1ff7f0a17bdd8b9f07198ab1bb4666d>`_)
+* hdf5-blosc2 plugin (from `PyTables <https://github.com/PyTables/PyTables/>`_ v3.8.0)
   using `c-blosc2 <https://github.com/Blosc/c-blosc2>`_ (v2.6.1 + `patch <https://github.com/Blosc/c-blosc2/pull/436>`_),
   LZ4, ZLib and ZStd.
 * `FCIDECOMP plugin <ftp://ftp.eumetsat.int/pub/OPS/out/test-data/Test-data-for-External-Users/MTG_FCI_Test-Data/FCI_Decompression_Software_V1.0.2>`_ (v1.0.2)

--- a/doc/information.rst
+++ b/doc/information.rst
@@ -49,18 +49,38 @@ HDF5 filters and compression libraries
 
 HDF5 compression filters and compression libraries sources were obtained from:
 
-* **LZ4 plugin** (commit `d48f960 <https://github.com/nexusformat/HDF5-External-Filter-Plugins/tree/d48f96064cb6e229ede4bf5e5c0e1935cf691036>`_) and **lz4** (v1.9.4): https://github.com/nexusformat/HDF5-External-Filter-Plugins and https://github.com/Blosc/c-blosc2/tree/v2.6.1/internal-complibs/lz4-1.9.4
-* **bitshuffle plugin** (0.5.1) and **zstd** (v1.5.2): https://github.com/kiyo-masui/bitshuffle, https://github.com/Blosc/c-blosc2/tree/v2.6.1/internal-complibs/lz4-1.9.4 and https://github.com/Blosc/c-blosc2/tree/v2.6.1/internal-complibs/zstd-1.5.2
-* **bzip2 plugin** (from PyTables v3.7.0) and **bzip2** (v1.0.8): https://github.com/PyTables/PyTables/, https://sourceware.org/git/bzip2.git
-* **hdf5-blosc plugin** (v1.0.0), **c-blosc** (v1.21.2) and **snappy** (v1.1.9): https://github.com/Blosc/hdf5-blosc, https://github.com/Blosc/c-blosc and https://github.com/google/snappy
-* **hdf5-blosc2 plugin** (from PyTables commit `8b8c7bc <https://github.com/PyTables/PyTables/commit/8b8c7bc7b1ff7f0a17bdd8b9f07198ab1bb4666d>`_), **c-blosc2** (`v2.6.1 <https://github.com/Blosc/c-blosc2/releases/tag/v2.6.1>`_ + `patch <https://github.com/Blosc/c-blosc2/pull/436>`_): https://github.com/PyTables/PyTables/, https://github.com/Blosc/c-blosc2
-* **FCIDECOMP plugin** (v1.0.2) and **CharLS** (1.x branch, commit `25160a4 <https://github.com/team-charls/charls/tree/25160a42fb62e71e4b0ce081f5cb3f8bb73938b5>`_):
-  ftp://ftp.eumetsat.int/pub/OPS/out/test-data/Test-data-for-External-Users/MTG_FCI_Test-Data/FCI_Decompression_Software_V1.0.2 and
-  https://github.com/team-charls/charls
-* **SZ plugin** (commit `c25805c12b3 <https://github.com/szcompressor/SZ/commit/c25805c12b339d2cb2f406f95293b9a7313c4fb1>`_), `SZ <https://github.com/szcompressor/SZ>`_, `zlib <https://github.com/Blosc/c-blosc/tree/9dc93b1de7c1ff6265d0ae554bd79077840849d8/internal-complibs/zlib-1.2.11>`_ (v1.2.11) and `zstd <https://github.com/Blosc/c-blosc2/tree/v2.6.1/internal-complibs/zstd-1.5.2>`_ (v1.5.2)
-* **SZ3 plugin** (commit `4bbe9df7e4bcb <https://github.com/szcompressor/SZ3/commit/4bbe9df7e4bcb6ae6339fcb3033100da07fe7434>`_), `SZ3 <https://github.com/szcompressor/SZ3>`_ and `zstd <https://github.com/Blosc/c-blosc2/tree/v2.6.1/internal-complibs/zstd-1.5.2>`_ (v1.5.2)
-* **HDF5-ZFP plugin** (commit `cd5422c <https://github.com/LLNL/H5Z-ZFP/tree/cd5422c146836e17c7a0380bfb05cf52d0c4467c>`_) and **zfp** (v1.0.0): https://github.com/LLNL/H5Z-ZFP and https://github.com/LLNL/zfp
-* **HDF5Plugin-Zstandard** (commit `d5afdb5 <https://github.com/aparamon/HDF5Plugin-Zstandard/tree/d5afdb5f04116d5c2d1a869dc9c7c0c72832b143>`_) and **zstd** (v1.5.2): https://github.com/aparamon/HDF5Plugin-Zstandard and https://github.com/Blosc/c-blosc2/tree/v2.6.1/internal-complibs/zstd-1.5.2
+* `LZ4 plugin <https://github.com/nexusformat/HDF5-External-Filter-Plugins>`_ 
+  (commit `d48f960 <https://github.com/nexusformat/HDF5-External-Filter-Plugins/tree/d48f96064cb6e229ede4bf5e5c0e1935cf691036>`_)
+  using LZ4.
+* `bitshuffle plugin <https://github.com/kiyo-masui/bitshuffle>`_ (v0.5.1) using LZ4 and ZStd.
+* bzip2 plugin (from `PyTables <https://github.com/PyTables/PyTables/>`_ v3.7.0)
+  using `BZip2 <https://sourceware.org/git/bzip2.git>`_ (v1.0.8).
+* `hdf5-blosc plugin <https://github.com/Blosc/hdf5-blosc>`_ (v1.0.0)
+  using `c-blosc <https://github.com/Blosc/c-blosc>`_ (v1.21.2), LZ4, Snappy, ZLib and ZStd.
+* hdf5-blosc2 plugin (from `PyTables <https://github.com/PyTables/PyTables/>`_ commit `8b8c7bc <https://github.com/PyTables/PyTables/commit/8b8c7bc7b1ff7f0a17bdd8b9f07198ab1bb4666d>`_)
+  using `c-blosc2 <https://github.com/Blosc/c-blosc2>`_ (v2.6.1 + `patch <https://github.com/Blosc/c-blosc2/pull/436>`_),
+  LZ4, ZLib and ZStd.
+* `FCIDECOMP plugin <ftp://ftp.eumetsat.int/pub/OPS/out/test-data/Test-data-for-External-Users/MTG_FCI_Test-Data/FCI_Decompression_Software_V1.0.2>`_ (v1.0.2)
+  using `CharLS <https://github.com/team-charls/charls>`_
+  (1.x branch, commit `25160a4 <https://github.com/team-charls/charls/tree/25160a42fb62e71e4b0ce081f5cb3f8bb73938b5>`_).
+* `SZ plugin <https://github.com/szcompressor/SZ>`_
+  (commit `c25805c12b3 <https://github.com/szcompressor/SZ/commit/c25805c12b339d2cb2f406f95293b9a7313c4fb1>`_)
+  using `SZ <https://github.com/szcompressor/SZ>`_, ZLib and ZStd.
+* `SZ3 plugin <https://github.com/szcompressor/SZ3>`_
+  (commit `4bbe9df7e4bcb <https://github.com/szcompressor/SZ3/commit/4bbe9df7e4bcb6ae6339fcb3033100da07fe7434>`_)
+  using `SZ3 <https://github.com/szcompressor/SZ3>`_ and ZStd.
+* `HDF5-ZFP plugin <https://github.com/LLNL/H5Z-ZFP>`_
+  (commit `cd5422c <https://github.com/LLNL/H5Z-ZFP/tree/cd5422c146836e17c7a0380bfb05cf52d0c4467c>`_)
+  using `zfp <https://github.com/LLNL/zfp>`_ (v1.0.0).
+* `HDF5Plugin-Zstandard <https://github.com/aparamon/HDF5Plugin-Zstandard>`_
+  (commit `d5afdb5 <https://github.com/aparamon/HDF5Plugin-Zstandard/tree/d5afdb5f04116d5c2d1a869dc9c7c0c72832b143>`_) using ZStd.
+
+Sources of compression libraries shared accross multiple filters were obtained from:
+
+* `LZ4 v1.9.4 <https://github.com/Blosc/c-blosc2/tree/v2.6.1/internal-complibs/lz4-1.9.4>`_
+* `Snappy v1.1.9 <https://github.com/google/snappy>`_
+* `ZStd v1.5.2 <https://github.com/Blosc/c-blosc2/tree/v2.6.1/internal-complibs/zstd-1.5.2>`_
+* `ZLib v1.2.11 <https://github.com/Blosc/c-blosc/tree/9dc93b1de7c1ff6265d0ae554bd79077840849d8/internal-complibs/zlib-1.2.11>`_
 
 When compiled with Intel IPP, the LZ4 compression library is replaced with `LZ4 v1.9.3 <https://github.com/lz4/lz4/releases/tag/v1.9.3>`_ patched with a patch from Intel IPP 2021.7.0.
 


### PR DESCRIPTION
This PR reworks the list of filter and compression libs source links.
The goal is to make it simpler to maintain by avoiding duplicated links to compression libs using by mulitple filters.
It also simplifies the display by not displaying the URLs any more.

![Screenshot from 2023-01-16 10-31-46](https://user-images.githubusercontent.com/9449698/212644779-a5527fff-19d9-46ac-87b5-d3f87e26a365.png)


See previous: http://www.silx.org/doc/hdf5plugin/4.0.0/information.html#hdf5-filters-and-compression-libraries