### PR TITLE
Updated build configuration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -885,7 +885,10 @@ def get_blosc2_plugin():
     extra_link_args = []
     libraries = []
 
-    sse2_kwargs = {'define_macros': [('SHUFFLE_SSE2_ENABLED', 1)]}
+    if platform.machine() == 'ppc64le':
+        sse2_kwargs = {}
+    else:
+        sse2_kwargs = {'define_macros': [('SHUFFLE_SSE2_ENABLED', 1)]}
     avx2_kwargs = {'define_macros': [('SHUFFLE_AVX2_ENABLED', 1)]}
 
     # compression libs

--- a/setup.py
+++ b/setup.py
@@ -534,6 +534,14 @@ class PluginBuildExt(build_ext):
                     for name, value in e.cpp11.items():
                         attribute = getattr(e, name)
                         attribute += value
+                if config.use_sse2:
+                    for name, value in e.sse2.items():
+                        attribute = getattr(e, name)
+                        attribute += value
+                if config.use_avx2:
+                    for name, value in e.avx2.items():
+                        attribute = getattr(e, name)
+                        attribute += value
 
             if not config.use_openmp:  # Remove OpenMP flags
                 e.extra_compile_args = [
@@ -554,7 +562,7 @@ class PluginBuildExt(build_ext):
 class HDF5PluginExtension(Extension):
     """Extension adding specific things to build a HDF5 plugin"""
 
-    def __init__(self, name, cpp11=None, cpp11_required=False, **kwargs):
+    def __init__(self, name, sse2=None, avx2=None, cpp11=None, cpp11_required=False, **kwargs):
         Extension.__init__(self, name, **kwargs)
 
         if not self.depends:
@@ -573,6 +581,8 @@ class HDF5PluginExtension(Extension):
 
         self.define_macros.append(('H5_USE_18_API', None))
 
+        self.sse2 = sse2 if sse2 is not None else {}
+        self.avx2 = avx2 if avx2 is not None else {}
         self.cpp11 = cpp11 if cpp11 is not None else {}
         self.cpp11_required = cpp11_required
 
@@ -797,12 +807,17 @@ def get_blosc_plugin():
     # blosc sources
     sources = glob(f'{blosc_dir}/*.c')
     include_dirs = ['src/c-blosc', blosc_dir]
-    define_macros = [
-        ('SHUFFLE_SSE2_ENABLED', 1),
-        ('SHUFFLE_AVX2_ENABLED', 1),
-    ]
+    define_macros = []
     extra_link_args = []
     libraries = []
+
+    if platform.machine() == 'ppc64le':
+        # SSE2 support in blosc uses x86 assembly code in shuffle
+        sse2_kwargs = {}
+    else:
+        sse2_kwargs = {'define_macros': [('SHUFFLE_SSE2_ENABLED', 1)]}
+
+    avx2_kwargs = {'define_macros': [('SHUFFLE_AVX2_ENABLED', 1)]}
 
     # compression libs
     # lz4
@@ -843,6 +858,8 @@ def get_blosc_plugin():
         extra_compile_args=extra_compile_args,
         extra_link_args=extra_link_args,
         libraries=libraries,
+        sse2=sse2_kwargs,
+        avx2=avx2_kwargs,
         cpp11=cpp11_kwargs,
     )
 
@@ -862,13 +879,14 @@ def get_blosc2_plugin():
     sources = glob(f'{blosc2_dir}/blosc/*.c')
     include_dirs = [blosc2_dir, f'{blosc2_dir}/blosc', f'{blosc2_dir}/include']
     define_macros = [
-        ('SHUFFLE_SSE2_ENABLED', 1),
-        ('SHUFFLE_AVX2_ENABLED', 1),
         ('SHUFFLE_NEON_ENABLED', 1),
         ('SHUFFLE_ALTIVEC_ENABLED', 1),
     ]
     extra_link_args = []
     libraries = []
+
+    sse2_kwargs = {'define_macros': [('SHUFFLE_SSE2_ENABLED', 1)]}
+    avx2_kwargs = {'define_macros': [('SHUFFLE_AVX2_ENABLED', 1)]}
 
     # compression libs
     # lz4
@@ -906,6 +924,8 @@ def get_blosc2_plugin():
         extra_compile_args=extra_compile_args,
         extra_link_args=extra_link_args,
         libraries=libraries,
+        sse2=sse2_kwargs,
+        avx2=avx2_kwargs,
     )
 
 


### PR DESCRIPTION
This PR partly reverts PR #255 so that it ensures SSE2/AVX2 support is disabled in blosc/blosc2 when requested (else it could be enabled with HDF5PLUGIN_NATIVE=True...).
This also reworks the way to handle SSE2 intrinsics support on P9: It makes it explicit in bitshuffle and use altivec for blosc2 rather than combining it with SSE2: Now SSE2 is only for x86.