### PR TITLE
[CI] Test h5py 3.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,11 @@ jobs:
             H5PY_OLDER_VERSION: 2.10.0
             NUMPY_OLDER_VERSION: 1.23.5
 
-          - name-suffix: "sdist-h5py_3.6.0"
+          - name-suffix: "sdist-h5py_3.8.0"
             os: ubuntu-latest
             python-version: 3.10.8
             BUILD_COMMAND: bdist_wheel
-            H5PY_OLDER_VERSION: 3.6.0
+            H5PY_OLDER_VERSION: 3.8.0
 
           - name-suffix: "bdist_wheel-h5py_2.10.0"
             os: macos-latest
@@ -49,11 +49,11 @@ jobs:
             BUILD_COMMAND: bdist_wheel
             H5PY_OLDER_VERSION: 2.10.0
 
-          - name-suffix: "bdist_wheel-h5py_3.0.0"
+          - name-suffix: "bdist_wheel-h5py_3.8.0"
             os: macos-latest
             python-version: 3.10.8
             BUILD_COMMAND: bdist_wheel
-            H5PY_OLDER_VERSION: 3.6.0
+            H5PY_OLDER_VERSION: 3.8.0
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,10 +13,10 @@ environment:
 
     matrix:
         # Python 3.10
-        - BUILD_PY_PATH: "C:\\Python310-x64;C:\\Python310-x64\\Scripts"
-          TEST_PY_PATH: "C:\\Python310-x64;C:\\Python310-x64\\Scripts"
+        - BUILD_PY_PATH: "C:\\Python311-x64;C:\\Python311-x64\\Scripts"
+          TEST_PY_PATH: "C:\\Python311-x64;C:\\Python311-x64\\Scripts"
           INSTALL_CMD: "python -m pip install --upgrade --pre"
-          H5PY_OLDER_VERSION: "3.6.0"
+          H5PY_OLDER_VERSION: "3.8.0"
 
         # Miniconda37
         - BUILD_PY_PATH: "C:\\Python37-x64;C:\\Python37-x64\\Scripts"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
         WIN_SDK_ROOT: "C:\\Program Files\\Microsoft SDKs\\Windows"
 
     matrix:
-        # Python 3.10
+        # Python 3.11
         - BUILD_PY_PATH: "C:\\Python311-x64;C:\\Python311-x64\\Scripts"
           TEST_PY_PATH: "C:\\Python311-x64;C:\\Python311-x64\\Scripts"
           INSTALL_CMD: "python -m pip install --upgrade --pre"


### PR DESCRIPTION
- Upgrade latest h5py to 3.8.0
- Upgrade windows tests to python 3.11