### PR TITLE
Fixed blosc2 compile flags on ARM hosts; Prepare v4.1.1 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+4.1.1: 23/01/2023
+-----------------
+
+This is a bug fix release:
+
+- Fixed **c-blosc2** compilation on ARM architecture (PR #262)
+- Updated continuous integration tests (PR #261)
+
 4.1.0: 17/01/2023
 -----------------
 

--- a/setup.py
+++ b/setup.py
@@ -868,12 +868,17 @@ def get_blosc2_plugin():
     sources = glob(f'{blosc2_dir}/blosc/*.c')
     include_dirs = [blosc2_dir, f'{blosc2_dir}/blosc', f'{blosc2_dir}/include']
     define_macros = [('SHUFFLE_NEON_ENABLED', 1)]
+    extra_compile_args = []
     extra_link_args = []
     libraries = []
 
     if platform.machine() == 'ppc64le':
         define_macros.append(('SHUFFLE_ALTIVEC_ENABLED', 1))
         define_macros.append(('NO_WARN_X86_INTRINSICS', None))
+    if HostConfig.ARCH == 'ARM_8':
+        extra_compile_args += ['-flax-vector-conversions']
+    if HostConfig.ARCH == 'ARM_7':
+        extra_compile_args += ['-mfpu=neon', '-flax-vector-conversions']
 
     # compression libs
     # lz4
@@ -895,7 +900,7 @@ def get_blosc2_plugin():
     include_dirs += get_zstd_clib('include_dirs')
     define_macros.append(('HAVE_ZSTD', 1))
 
-    extra_compile_args = ['-std=gnu99']  # Needed to build manylinux1 wheels
+    extra_compile_args += ['-std=gnu99']  # Needed to build manylinux1 wheels
     extra_compile_args += ['-O3', '-ffast-math']
     extra_compile_args += ['/Ox', '/fp:fast']
     extra_compile_args += ['-pthread']

--- a/src/hdf5plugin/_version.py
+++ b/src/hdf5plugin/_version.py
@@ -72,7 +72,7 @@ PRERELEASE_NORMALIZED_NAME = {"dev": "a",
 
 MAJOR = 4
 MINOR = 1
-MICRO = 0
+MICRO = 1
 RELEV = "final"  # <16
 SERIAL = 0  # <16
 


### PR DESCRIPTION
This PR fixes build on ARM with gcc by adding necessary flags (as in c-blosc2 cmakefile).
Tested on macos/ARM, raspberrypi and with conda-forge environement for cross-compilation of `aarch64`.

It also prepare for a 4.1.1 bug fix release.

closes #260