### PR TITLE
Updated dependency to `wheel`>=0.34.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["py-cpuinfo==8.0.0", "setuptools", "wheel"]
+requires = ["py-cpuinfo==8.0.0", "setuptools", "wheel>=0.34.0"]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ setuptools
 sphinx
 sphinx_rtd_theme
 nbsphinx
-wheel
+wheel>=0.34.0


### PR DESCRIPTION
This PR requires at least wheel>=[0.34.0](https://pypi.org/project/wheel/0.34.0/) (from January 2020).
This simplifies a bit `setup.py` and remove deprecated dependency on `pkg_resources`