### PR TITLE
Removed import of `distutils`

### DIFF
--- a/package/debian11/control
+++ b/package/debian11/control
@@ -7,7 +7,8 @@ Build-Depends: debhelper-compat (= 12),
                libgomp1,
                python3-all-dev,
                python3-h5py,
-               python3-setuptools
+               python3-setuptools,
+               python3-wheel
 Standards-Version: 4.1.3
 Homepage: https://github.com/silx-kit/hdf5plugin
 

--- a/setup.py
+++ b/setup.py
@@ -1351,7 +1351,7 @@ if __name__ == "__main__":
           package_dir={'': 'src'},
           ext_modules=extensions,
           install_requires=['h5py'],
-          setup_requires=['setuptools'],
+          setup_requires=['setuptools', 'wheel'],
           extras_require={'dev': ['sphinx', 'sphinx_rtd_theme']},
           cmdclass=cmdclass,
           libraries=libraries,


### PR DESCRIPTION
This PR aims at removing the import of `distutils` by using an approach proposed in https://github.com/pypa/setuptools/issues/2806#issuecomment-961805789.

Imports of `distutils` as fallbacks for older versions of `setuptools` are kept for now.

related to  #193