### PR TITLE
Update hdf5-blosc2 to support b2nd

### DIFF
--- a/doc/information.rst
+++ b/doc/information.rst
@@ -57,7 +57,7 @@ HDF5 compression filters and compression libraries sources were obtained from:
   using `BZip2 <https://sourceware.org/git/bzip2.git>`_ (v1.0.8).
 * `hdf5-blosc plugin <https://github.com/Blosc/hdf5-blosc>`_ (v1.0.0)
   using `c-blosc <https://github.com/Blosc/c-blosc>`_ (v1.21.5), LZ4, Snappy, ZLib and ZStd.
-* hdf5-blosc2 plugin (from `PyTables <https://github.com/PyTables/PyTables/>`_ v3.9.2.dev0)
+* hdf5-blosc2 plugin (from `PyTables <https://github.com/PyTables/PyTables/>`_ v3.9.2.dev0, commit `3ba4e78 <https://github.com/PyTables/PyTables/tree/3ba4e78336f21f5e32ddf49ced4560f610de70dd/hdf5-blosc2/src>`_)
   using `c-blosc2 <https://github.com/Blosc/c-blosc2>`_ (v2.10.2), LZ4, ZLib and ZStd.
 * `FCIDECOMP plugin <ftp://ftp.eumetsat.int/pub/OPS/out/test-data/Test-data-for-External-Users/MTG_FCI_Test-Data/FCI_Decompression_Software_V1.0.2>`_ (v1.0.2)
   using `CharLS <https://github.com/team-charls/charls>`_

--- a/doc/information.rst
+++ b/doc/information.rst
@@ -57,7 +57,7 @@ HDF5 compression filters and compression libraries sources were obtained from:
   using `BZip2 <https://sourceware.org/git/bzip2.git>`_ (v1.0.8).
 * `hdf5-blosc plugin <https://github.com/Blosc/hdf5-blosc>`_ (v1.0.0)
   using `c-blosc <https://github.com/Blosc/c-blosc>`_ (v1.21.5), LZ4, Snappy, ZLib and ZStd.
-* hdf5-blosc2 plugin (from `PyTables <https://github.com/PyTables/PyTables/>`_ v3.8.0)
+* hdf5-blosc2 plugin (from `PyTables <https://github.com/PyTables/PyTables/>`_ v3.9.2.dev0)
   using `c-blosc2 <https://github.com/Blosc/c-blosc2>`_ (v2.10.2), LZ4, ZLib and ZStd.
 * `FCIDECOMP plugin <ftp://ftp.eumetsat.int/pub/OPS/out/test-data/Test-data-for-External-Users/MTG_FCI_Test-Data/FCI_Decompression_Software_V1.0.2>`_ (v1.0.2)
   using `CharLS <https://github.com/team-charls/charls>`_

--- a/src/PyTables/hdf5-blosc2/src/blosc2_filter.c
+++ b/src/PyTables/hdf5-blosc2/src/blosc2_filter.c
@@ -12,8 +12,10 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <assert.h>
 #include "hdf5.h"
 #include "blosc2_filter.h"
+#include "b2nd.h"
 
 #if defined(__GNUC__)
 #define PUSH_ERR(func, minor, str, ...) H5Epush(H5E_DEFAULT, __FILE__, func, __LINE__, H5E_ERR_CLS, H5E_PLINE, minor, str, ##__VA_ARGS__)
@@ -26,6 +28,30 @@
 #endif	/* defined(__GNUC__) */
 
 #define GET_FILTER(a, b, c, d, e, f, g) H5Pget_filter_by_id(a,b,c,d,e,f,g,NULL)
+
+/* Auxiliary filter values are:
+ *
+ * - 0: filter revision (FILTER_BLOSC2_VERSION)
+ * - 1: block size (in bytes)
+ * - 2: type size (in bytes)
+ * - 3: chunk size (in bytes)
+ * - 4: compression level
+ * - 5: shuffle method
+ * - 6: compressor code
+ * - 7: chunk rank (number of dimensions) (present if 1 < rank <= BLOSC2_MAX_DIM, for B2ND)
+ * - 8 + i: length of chunk dimension i (0 <= i < rank)
+ *
+ * If a value is specified, all values before it must be specified too.
+ *
+ * If the chunk rank is specified, chunk dimensions must follow.
+ */
+#define MAX_FILTER_VALUES (8 + BLOSC2_MAX_DIM)
+/* Compression level default */
+#define DEFAULT_CLEVEL 5
+/* Shuffle default */
+#define DEFAULT_SHUFFLE 1
+  /* Codec by default */
+#define DEFAULT_COMPCODE BLOSC_BLOSCLZ
 
 
 size_t blosc2_filter_function(unsigned flags, size_t cd_nelmts,
@@ -51,7 +77,7 @@ int register_blosc2(char **version, char **date){
     };
 
     retval = H5Zregister(&filter_class);
-    if(retval<0){
+    if (retval < 0){
         PUSH_ERR("register_blosc2", H5E_CANTREGISTER, "Can't register Blosc2 filter");
     }
     if (version != NULL && date != NULL) {
@@ -63,42 +89,44 @@ int register_blosc2(char **version, char **date){
 
 /*  Filter setup.  Records the following inside the DCPL:
 
-    1. If version information is not present, set slots 0 and 1 to the filter
-       revision and Blosc2 version, respectively.
+    1. Set slot 0 to the filter revision.
 
     2. Compute the type size in bytes and store it in slot 2.
 
     3. Compute the chunk size in bytes and store it in slot 3.
+
+    4. If 1 < rank <= BLOSC2_MAX_DIM, store it in slot 7, and chunk dimensions in the following slots.
 */
 herr_t blosc2_set_local(hid_t dcpl, hid_t type, hid_t space) {
 
-  int ndims;
+  int ndim;
   int i;
   herr_t r;
 
   unsigned int typesize, basetypesize;
   unsigned int bufsize;
-  hsize_t chunkdims[32];
+  hsize_t chunkshape[H5S_MAX_RANK];
   unsigned int flags;
-  size_t nelements = 8;
-  unsigned int values[] = {0, 0, 0, 0, 0, 0, 0, 0};
+  size_t nelements = MAX_FILTER_VALUES;
+  unsigned int values[MAX_FILTER_VALUES];
   hid_t super_type;
   H5T_class_t classt;
 
+  memset(values, 0, sizeof(values));
   r = GET_FILTER(dcpl, FILTER_BLOSC2, &flags, &nelements, values, 0, NULL);
   if (r < 0) return -1;
 
   if (nelements < 4)
     nelements = 4;  /* First 4 slots reserved. */
 
-  /* Set Blosc2 info in first two slots */
+  /* Set Blosc2 info in first slot */
   values[0] = FILTER_BLOSC2_VERSION;
 
-  ndims = H5Pget_chunk(dcpl, 32, chunkdims);
-  if (ndims < 0)
+  ndim = H5Pget_chunk(dcpl, H5S_MAX_RANK, chunkshape);
+  if (ndim < 0)
     return -1;
-  if (ndims > 32) {
-    PUSH_ERR("blosc2_set_local", H5E_CALLBACK, "Chunk rank exceeds limit");
+  if (ndim > H5S_MAX_RANK) {
+    PUSH_ERR("blosc2_set_local", H5E_CALLBACK, "Chunk rank exceeds HDF5 limit");
     return -1;
   }
 
@@ -116,28 +144,36 @@ herr_t blosc2_set_local(hid_t dcpl, hid_t type, hid_t space) {
     basetypesize = typesize;
   }
 
-  /* Limit large typesizes (they are pretty expensive to shuffle
-     and, in addition, Blosc2 does not handle typesizes larger than
-     255 bytes). */
-  /* But for reads, it is useful to have the original typesize here.
-   * And there is no harm in storing the original typesize here, as Blosc2
-   * will decide internally to reduce it to 1 if > BLOSC_MAX_TYPESIZE.
-   */
-  /* if (basetypesize > BLOSC_MAX_TYPESIZE)
-   *  basetypesize = 1;
-   */
   values[2] = basetypesize;
 
   /* Get the size of the chunk */
   bufsize = typesize;
-  for (i = 0; i < ndims; i++) {
-    bufsize *= (unsigned int) chunkdims[i];
+  for (i = 0; i < ndim; i++) {
+    bufsize *= (unsigned int) chunkshape[i];
   }
   values[3] = bufsize;
 
 #ifdef BLOSC2_DEBUG
   fprintf(stderr, "Blosc2: Computed buffer size %d\n", bufsize);
 #endif
+
+  if (1 < ndim && ndim <= BLOSC2_MAX_DIM) {
+    if (nelements < 5) { values[4] = DEFAULT_CLEVEL; }
+    if (nelements < 6) { values[5] = DEFAULT_SHUFFLE; }
+    if (nelements < 7) { values[6] = DEFAULT_COMPCODE; }
+
+    values[7] = ndim;
+    for (int i = 0; i < ndim; i++) {
+      values[8 + i] = (unsigned int)(chunkshape[i]);
+    };
+
+    nelements = 8 + ndim;
+  } else if (ndim > 1) {
+    /* The user may be expecting more efficient storage than we can currently provide,
+     * so convey some information when tracing. */
+    BLOSC_TRACE_WARNING("Chunk rank %d exceeds B2ND build limit %d, "
+                        "using plain Blosc2 instead", ndim, BLOSC2_MAX_DIM);
+  }
 
   r = H5Pmodify_filter(dcpl, FILTER_BLOSC2, flags, nelements, values);
   if (r < 0)
@@ -146,6 +182,93 @@ herr_t blosc2_set_local(hid_t dcpl, hid_t type, hid_t space) {
   return 1;
 }
 
+
+/* From Blosc2's "examples/get_blocksize.c". */
+int32_t compute_blosc2_blocksize(int32_t chunksize, int32_t typesize,
+                                 int clevel, int compcode) {
+  static uint8_t data_dest[BLOSC2_MAX_OVERHEAD];
+  blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
+  cparams.compcode = (compcode < 0) ? DEFAULT_COMPCODE : compcode;
+  cparams.clevel = clevel;
+  cparams.typesize = typesize;
+
+  if (blosc2_chunk_zeros(cparams, chunksize, data_dest, BLOSC2_MAX_OVERHEAD) < 0) {
+    BLOSC_TRACE_ERROR("Failed to create zeroed chunk for blocksize computation");
+    return -1;
+  }
+
+  int32_t blocksize = -1;
+  if (blosc2_cbuffer_sizes(data_dest, NULL, NULL, &blocksize) < 0) {
+    BLOSC_TRACE_ERROR("Failed to get chunk sizes for blocksize computation");
+    return -1;
+  }
+  return blocksize;
+}
+
+
+/* Get the maximum block size which is not greater than the given block_size
+ * and fits within the given chunk dimensions dims_chunk. Sizes must always be
+ * greater than 0.
+ *
+ * Block dimensions start with 2 (unless the respective chunk dimension is 1),
+ * and are doubled starting from the innermost (rightmost) ones, to leverage
+ * the locality of C array arrangement.  The resulting block dimensions are
+ * placed in the last (output) argument.
+ *
+ * Based on Python-Blosc2's blosc2.core.compute_chunks_blocks and
+ * compute_partition.
+ */
+int32_t compute_b2nd_block_shape(size_t block_size,
+                                 size_t type_size,
+                                 const int rank,
+                                 const int32_t *dims_chunk,
+                                 int32_t *dims_block) {
+  assert(block_size >= 0);
+  assert(type_size >= 0);
+  size_t nitems = block_size / type_size;
+
+  // Start with the smallest possible block dimensions (1 or 2).
+  size_t nitems_new = 1;
+  for (int i = 0; i < rank; i++) {
+    assert(dims_chunk[i] != 0);
+    dims_block[i] = dims_chunk[i] == 1 ? 1 : 2;
+    nitems_new *= dims_block[i];
+  }
+
+  if (nitems_new > nitems) {
+    BLOSC_TRACE_INFO("Target block size is too small (%lu items), raising to %lu items",
+                     nitems, nitems_new);
+  }
+  if (nitems_new >= nitems) {
+    return nitems_new * type_size;
+  }
+
+  // Double block dimensions (bound by chunk dimensions) from right to left
+  // while block is under nitems.
+  while (nitems_new < nitems) {
+    size_t nitems_prev = nitems_new;
+    for (int i = rank - 1; i >= 0; i--) {
+      if (dims_block[i] * 2 <= dims_chunk[i]) {
+        if (nitems_new * 2 <= nitems) {
+          nitems_new *= 2;
+          dims_block[i] *= 2;
+        }
+      } else if (dims_block[i] < dims_chunk[i]) {
+        size_t newitems_ext = (nitems_new / dims_block[i]) * dims_chunk[i];
+        if (newitems_ext <= nitems) {
+          nitems_new = newitems_ext;
+          dims_block[i] = dims_chunk[i];
+        }
+      } else {
+        assert(dims_block[i] == dims_chunk[i]);  // nothing to change
+      }
+    }
+    if (nitems_new == nitems_prev) {
+      break;  // not progressing anymore
+    }
+  }
+  return nitems_new * type_size;
+}
 
 /* The filter function */
 size_t blosc2_filter_function(unsigned flags, size_t cd_nelmts,
@@ -157,19 +280,61 @@ size_t blosc2_filter_function(unsigned flags, size_t cd_nelmts,
   size_t blocksize;
   size_t typesize;
   size_t outbuf_size;
-  int clevel = 5;                /* Compression level default */
-  int doshuffle = 1;             /* Shuffle default */
-  int compcode = BLOSC_BLOSCLZ;  /* Codec by default */
+  int clevel = DEFAULT_CLEVEL;
+  int doshuffle = DEFAULT_SHUFFLE;
+  int compcode = DEFAULT_COMPCODE;
+
+  if (cd_nelmts < 4) {
+    PUSH_ERR("blosc2_filter", H5E_CALLBACK,
+             "Too few filter parameters for B2ND: %d", cd_nelmts);
+    goto failed;
+  }
 
   /* Filter params that are always set */
   blocksize = cd_values[1];      /* The block size */
   typesize = cd_values[2];      /* The datatype size */
   outbuf_size = cd_values[3];   /* Precomputed buffer guess */
 
+  /* Filter params that are only set for B2ND */
+  int ndim = -1;
+  int32_t chunkshape[BLOSC2_MAX_DIM];
+  if (cd_nelmts >= 8) {
+    /* Get chunk shape for B2ND */
+    ndim = cd_values[7];
+    if (ndim < 2) {
+      PUSH_ERR("blosc2_filter", H5E_CALLBACK,
+               "Chunk rank %d (filter value) is too small for B2ND",
+               ndim);
+      goto failed;
+    }
+    if (ndim > BLOSC2_MAX_DIM) {
+      PUSH_ERR("blosc2_filter", H5E_CALLBACK,
+               "Chunk rank %d (filter value) exceeds B2ND build limit %d",
+               ndim, BLOSC2_MAX_DIM);
+      goto failed;
+    }
+    if (cd_nelmts < (size_t)(8 + ndim)) {
+      PUSH_ERR("blosc2_filter", H5E_CALLBACK,
+               "Too few dimensions for B2ND in filter values (%z/%d)",
+               cd_nelmts - 8, ndim);
+      goto failed;
+    }
+    for (int i = 0; i < ndim; i++) {
+      chunkshape[i] = cd_values[8 + i];
+    }
+  }
+
   blosc2_init();
 
   if (!(flags & H5Z_FLAG_REVERSE)) {
     /* We're compressing */
+
+    if (cd_nelmts < 6) {
+      PUSH_ERR("blosc2_filter", H5E_CALLBACK,
+               "Too few filter parameters for Blosc2 compression: %d", cd_nelmts);
+      goto failed;
+    }
+
     /* Compression params */
     clevel = cd_values[4];        /* The compression level */
     doshuffle = cd_values[5];     /* SHUFFLE, BITSHUFFLE, others */
@@ -198,29 +363,86 @@ size_t blosc2_filter_function(unsigned flags, size_t cd_nelmts,
     cparams.typesize = (int32_t) typesize;
     cparams.filters[BLOSC_LAST_FILTER] = doshuffle;
     cparams.clevel = clevel;
+    // cparams.blocksize depends on dimensionality
 
-    blosc2_context *cctx = blosc2_create_cctx(cparams);
     blosc2_storage storage = {.cparams=&cparams, .contiguous=false};
-    blosc2_schunk* schunk = blosc2_schunk_new(&storage);
-    if (schunk == NULL) {
-      PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Cannot create a super-chunk");
-      goto failed;
-    }
 
-    status = blosc2_schunk_append_buffer(schunk, *buf, (int32_t) nbytes);
-    if (status < 0) {
-      PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Cannot append to buffer");
-      goto failed;
-    }
+    if (ndim > 1) {
 
-    bool needs_free;
-    status = blosc2_schunk_to_buffer(schunk, (uint8_t **)&outbuf, &needs_free);
-    if (status < 0 || !needs_free) {
-      PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Cannot convert to buffer");
-      goto failed;
+      b2nd_context_t *ctx = NULL;
+      b2nd_array_t *array = NULL;
+
+      if (blocksize == 0) {
+        int32_t sugg_blocksize = compute_blosc2_blocksize(outbuf_size, typesize,
+                                                          clevel, compcode);
+        if (sugg_blocksize < 0) {
+          PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Failed to compute suggested blocksize");
+          goto failed;
+        }
+        blocksize = sugg_blocksize;
+      }
+      int32_t blockdims[BLOSC2_MAX_DIM];
+      cparams.blocksize = compute_b2nd_block_shape(blocksize, typesize,
+                                                   ndim, chunkshape,
+                                                   blockdims);
+
+      int64_t chunkshape_l[BLOSC2_MAX_DIM];
+      for (int i = 0; i < ndim; i++) {
+        chunkshape_l[i] = chunkshape[i];
+      }
+
+      char dtype[B2ND_OPAQUE_NPDTYPE_MAXLEN];
+      snprintf(dtype, sizeof(dtype), B2ND_OPAQUE_NPDTYPE_FORMAT, typesize);
+      if (!(ctx = b2nd_create_ctx(&storage,
+                                  ndim, chunkshape_l, chunkshape, blockdims,
+                                  dtype, DTYPE_NUMPY_FORMAT, NULL, 0))) {
+        PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Cannot create B2ND context");
+        goto b2nd_comp_out;
+      }
+
+      if (b2nd_from_cbuffer(ctx, &array, *buf, nbytes) < 0) {
+        PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Cannot compress buffer into B2ND array");
+        goto b2nd_comp_out;
+      }
+
+      bool needs_free;
+      if (b2nd_to_cframe(array, (uint8_t **)&outbuf, &status, &needs_free) < 0) {
+        PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Cannot convert B2ND array to buffer");
+        goto b2nd_comp_out;
+      }
+
+      b2nd_comp_out:
+      if (array) b2nd_free(array);
+      if (ctx) b2nd_free_ctx(ctx);
+
+    } else {
+      cparams.blocksize = blocksize;
+
+      blosc2_context *cctx = blosc2_create_cctx(cparams);
+      blosc2_schunk* schunk = blosc2_schunk_new(&storage);
+      if (schunk == NULL) {
+        PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Cannot create a super-chunk");
+        goto b2_comp_out;
+      }
+
+      status = blosc2_schunk_append_buffer(schunk, *buf, (int32_t) nbytes);
+      if (status < 0) {
+        PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Cannot append buffer to super-chunk");
+        goto b2_comp_out;
+      }
+
+      bool needs_free;
+      status = blosc2_schunk_to_buffer(schunk, (uint8_t **)&outbuf, &needs_free);
+      if (status < 0 || !needs_free) {
+        PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Cannot convert super-chunk to buffer");
+        goto b2_comp_out;
+      }
+
+      b2_comp_out:
+      if (schunk) blosc2_schunk_free(schunk);
+      if (cctx) blosc2_free_ctx(cctx);
+
     }
-    blosc2_schunk_free(schunk);
-    blosc2_free_ctx(cctx);
 
 #ifdef BLOSC2_DEBUG
     fprintf(stderr, "Blosc2: Compressed into %zd bytes\n", status);
@@ -237,43 +459,110 @@ size_t blosc2_filter_function(unsigned flags, size_t cd_nelmts,
       goto failed;
     }
 
-    uint8_t *chunk;
-    bool needs_free;
-    cbytes = blosc2_schunk_get_lazychunk(schunk, 0, &chunk, &needs_free);
-    if (cbytes < 0) {
-      PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Get chunk error");
-      goto failed;
-    }
+    /* Although blosc2_decompress_ctx ("else" branch) can decompress b2nd-formatted data,
+     * there may be padding bytes when the chunkshape is not a multiple of the blockshape,
+     * and only b2nd machinery knows how to handle these correctly.
+     */
+    if (blosc2_meta_exists(schunk, "b2nd") >= 0
+        || blosc2_meta_exists(schunk, "caterva") >= 0) {
 
-    /* Get the exact outbuf_size from the buffer header */
-    int32_t nbytes;
-    blosc2_cbuffer_sizes(chunk, &nbytes, NULL, NULL);
-    outbuf_size = nbytes;
+      if (ndim < 0) {
+        BLOSC_TRACE_WARNING("Auxiliary Blosc2 filter values contain no chunk rank/shape, "
+                            "some checks on B2ND arrays will be disabled");
+      }
+
+      b2nd_array_t *array = NULL;
+
+      if (b2nd_from_schunk(schunk, &array) < 0) {
+        PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Cannot create B2ND array from super-chunk");
+        goto b2nd_decomp_out;
+      }
+      schunk = NULL;  // owned by the array now, do not free on its own
+
+      /* Check array metadata against filter values */
+      if (ndim >= 0 && array->ndim != ndim) {
+        PUSH_ERR("blosc2_filter", H5E_CALLBACK,
+                 "B2ND array rank (%hhd) != filter rank (%d)", array->ndim, ndim);
+        goto b2nd_decomp_out;
+      }
+      int64_t start[BLOSC2_MAX_DIM], stop[BLOSC2_MAX_DIM], size = typesize;
+      for (int i = 0; i < array->ndim; i++) {
+        start[i] = 0;
+        stop[i] = array->shape[i];
+        size *= array->shape[i];
+        if (ndim >= 0 && array->shape[i] != chunkshape[i]) {
+          /* The HDF5 filter pipeline needs the filter to always return full chunks,
+           * even for margin chunks where data does not fill the whole chunk
+           * (in which case padding should be used
+           * (at least until the last byte with actual data).
+           * Of course, we need to know the chunkshape to check this.
+           */
+          PUSH_ERR("blosc2_filter", H5E_CALLBACK,
+                   "B2ND array shape[%d] (%ld) != filter chunkshape[%d] (%d)",
+                   i, array->shape[i], i, chunkshape[i]);
+          goto b2nd_decomp_out;
+        }
+      }
+      assert(outbuf_size >= size);
+
+      outbuf = malloc(outbuf_size);
+      if (outbuf == NULL) {
+        PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Cannot allocate decompression buffer");
+        goto b2nd_decomp_out;
+      }
+
+      if (b2nd_get_slice_cbuffer(array, start, stop,
+                                 outbuf, stop, outbuf_size) < 0) {
+        PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Cannot decompress B2ND array into buffer");
+        goto b2nd_decomp_out;
+      }
+      status = size;
+
+      b2nd_decomp_out:
+      if (array) b2nd_free(array);
+
+    } else {
+
+      uint8_t *chunk;
+      blosc2_context *dctx = NULL;
+
+      bool needs_free;
+      cbytes = blosc2_schunk_get_lazychunk(schunk, 0, &chunk, &needs_free);
+      if (cbytes < 0) {
+        PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Cannot get chunk from super-chunk");
+        goto b2_decomp_out;
+      }
+
+      /* Get the exact outbuf_size from the buffer header */
+      int32_t nbytes;
+      blosc2_cbuffer_sizes(chunk, &nbytes, NULL, NULL);
+      outbuf_size = nbytes;
 
 #ifdef BLOSC2_DEBUG
-    fprintf(stderr, "Blosc2: Decompress %zd chunk w/buffer %zd\n", nbytes, outbuf_size);
+      fprintf(stderr, "Blosc2: Decompress %zd chunk w/buffer %zd\n", nbytes, outbuf_size);
 #endif
 
-    outbuf = malloc(outbuf_size);
-    if (outbuf == NULL) {
-      PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Can't allocate decompression buffer");
-      goto failed;
+      outbuf = malloc(outbuf_size);
+      if (outbuf == NULL) {
+        PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Cannot allocate decompression buffer");
+        goto b2_decomp_out;
+      }
+
+      blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
+      dctx = blosc2_create_dctx(dparams);
+      status = blosc2_decompress_ctx(dctx, chunk, cbytes, outbuf, (int32_t) outbuf_size);
+      if (status <= 0) {
+        PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Cannot decompress chunk into buffer");
+        goto b2_decomp_out;
+      }
+
+      b2_decomp_out:
+      if (dctx) blosc2_free_ctx(dctx);
+      if (chunk && needs_free) free(chunk);
+
     }
 
-    blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
-    blosc2_context *dctx = blosc2_create_dctx(dparams);
-    status = blosc2_decompress_ctx(dctx, chunk, cbytes, outbuf, (int32_t) outbuf_size);
-    if (status <= 0) {
-      PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Blosc2 decompression error");
-      goto failed;
-    }
-
-    // Cleanup
-    if (needs_free) {
-      free(chunk);
-    }
-    blosc2_free_ctx(dctx);
-    blosc2_schunk_free(schunk);
+    if (schunk) blosc2_schunk_free(schunk);
 
   } /* compressing vs decompressing */
 
@@ -285,7 +574,7 @@ size_t blosc2_filter_function(unsigned flags, size_t cd_nelmts,
   }
 
   failed:
-  free(outbuf);
+  if (outbuf) free(outbuf);
   blosc2_destroy();
 
   return 0;

--- a/src/PyTables/hdf5-blosc2/src/blosc2_filter.h
+++ b/src/PyTables/hdf5-blosc2/src/blosc2_filter.h
@@ -14,11 +14,31 @@ extern "C" {
 /* See https://portal.hdfgroup.org/display/support/Filters */
 #define FILTER_BLOSC2 32026
 
+/* An opaque NumPy data type format for B2ND that respects the type size.
+ * The actual type is irrelevant since HDF5 already stores it. */
+#define B2ND_OPAQUE_NPDTYPE_FORMAT "|V%zd"
+
+/* The maximum size of a formatted NumPy data type string:
+ * "|V18446744073709551616\0". */
+#define B2ND_OPAQUE_NPDTYPE_MAXLEN (2 + 20 + 1)
+
 /* Registers the filter with the HDF5 library. */
 #if defined(_MSC_VER)
 __declspec(dllexport)
 #endif	/* defined(_MSC_VER) */
 int register_blosc2(char **version, char **date);
+
+/* Uses the Blosc2 library to decide an adequate block size for a chunk
+ * of chunksize bytes (with elements of typesize bytes),
+ * given the compression level clevel
+ * for the compressor compcode (negative for the default).
+ *
+ * Return a negative value if there is some error. */
+#if defined(_MSC_VER)
+__declspec(dllexport)
+#endif	/* defined(_MSC_VER) */
+int32_t compute_blosc2_blocksize(int32_t chunksize, int32_t typesize,
+                                 int clevel, int compcode);
 
 #ifdef __cplusplus
 }

--- a/src/hdf5plugin/_filters.py
+++ b/src/hdf5plugin/_filters.py
@@ -231,7 +231,7 @@ class Blosc2(_FilterRefClass):
         f.create_dataset(
             'blosc2_byte_shuffle_blosclz',
             data=numpy.arange(100),
-            **hdf5plugin.Blosc2(cname='blosclz', clevel=9, shuffle=hdf5plugin.Blosc2.SHUFFLE))
+            **hdf5plugin.Blosc2(cname='blosclz', clevel=9, filters=hdf5plugin.Blosc2.SHUFFLE))
         f.close()
 
     :param str cname:


### PR DESCRIPTION
This provides a few updates to support Blosc2 NDim NDim (2-level partitioning or b2nd, as introduced in Blosc2 2.7.0, see <https://www.blosc.org/posts/blosc2-ndim-intro/>) for arrays with rank >= 2. The code comes from PyTables master commit bb02c88 (where it passes all tests); part of it was already released in PyTables v3.9.0 and the rest will be in the next version (though it is completely compatible with the released one and not expected to change until then). A minor documentation fix and an updated unit test are also included.

For such b2nd-enabled arrays, each HDF5 chunk is stored as a Blosc2 multidimensional array with a fixed shape (even for margin chunks where data may not cover the whole chunk), consisting of a single inner chunk itself, and it also adds the HDF5 chunk rank and shape to stored filter parameters (so that further chunks added with the filter have consistent chunk and block sizes).

To enable reading datasets generated by other code, the filter is more lax regarding the inner structure of Blosc2 arrays (they may consist of several inner chunks or use different block sizes).  It may also work without the extra filter parameters (though it has to skip some data validation, so it warns about this).

See PyTables/PyTables#1056 and PyTables/PyTables#1072 for more information.