### PR TITLE
Documentation: Updated link to hdf5 registered filters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ hdf5plugin
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.7257761.svg
    :target: https://doi.org/10.5281/zenodo.7257761
 
-*hdf5plugin* provides `HDF5 compression filters <https://portal.hdfgroup.org/display/support/Registered+Filter+Plugins>`_ (namely: Blosc, Blosc2, BitShuffle, BZip2, FciDecomp, LZ4, SZ, SZ3, Zfp, ZStd) and makes them usable from `h5py <https://www.h5py.org>`_.
+*hdf5plugin* provides `HDF5 compression filters <https://portal.hdfgroup.org/documentation/hdf5-docs/registered_filter_plugins.html>`_ (namely: Blosc, Blosc2, BitShuffle, BZip2, FciDecomp, LZ4, SZ, SZ3, Zfp, ZStd) and makes them usable from `h5py <https://www.h5py.org>`_.
 
 See `documentation <http://www.silx.org/doc/hdf5plugin/latest/>`_.
 

--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -53,7 +53,7 @@ This briefly describes the steps to add a HDF5 compression filter to the zoo.
 * In case of import errors related to HDF5-related undefined symbols, add eventual missing functions under ``src/hdf5_dl.c``.
 
 * Add a "CONSTANT" in ``src/hdf5plugin/_filters.py`` named with the ``FILTER_NAME_ID`` which value is the HDF5 filter ID
-  (See `HDF5 registered filters <https://portal.hdfgroup.org/display/support/Registered+Filters>`_).
+  (See `HDF5 registered filters <https://portal.hdfgroup.org/documentation/hdf5-docs/registered_filter_plugins.html>`_).
 
 * Add a compression options helper class named ``FilterName`` in ``hdf5plugins/_filters.py`` which should inherit from ``_FilterRefClass``.
   This is intended to ease the usage of ``h5py.Group.create_dataset`` ``compression_opts`` argument.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,7 +1,7 @@
 hdf5plugin
 ==========
 
-*hdf5plugin* provides `HDF5 compression filters <https://portal.hdfgroup.org/display/support/Registered+Filter+Plugins>`_ (namely: Blosc, Blosc2, BitShuffle, BZip2, FciDecomp, LZ4, SZ, SZ3, Zfp, ZStd) and makes them usable from `h5py <https://www.h5py.org>`_.
+*hdf5plugin* provides `HDF5 compression filters <https://portal.hdfgroup.org/documentation/hdf5-docs/registered_filter_plugins.html>`_ (namely: Blosc, Blosc2, BitShuffle, BZip2, FciDecomp, LZ4, SZ, SZ3, Zfp, ZStd) and makes them usable from `h5py <https://www.h5py.org>`_.
 
 
 * Supported operating systems: Linux, Windows, macOS.

--- a/package/debian11/control
+++ b/package/debian11/control
@@ -19,7 +19,7 @@ Description: HDF5 Plugins for windows,MacOS and linux
  hdf5plugin
  ==========
  .
- This module provides `HDF5 compression filters <https://portal.hdfgroup.org/display/support/Registered+Filter+Plugins>`_ (namely: blosc, bitshuffle, bzip2,FCIDECOMP, lz4, ZFP, zstd) and registers them to the HDF5 library used by `h5py <https://www.h5py.org>`_.
+ This module provides `HDF5 compression filters <https://portal.hdfgroup.org/documentation/hdf5-docs/registered_filter_plugins.html>`_ (namely: blosc, bitshuffle, bzip2,FCIDECOMP, lz4, ZFP, zstd) and registers them to the HDF5 library used by `h5py <https://www.h5py.org>`_.
  .
  * Supported operating systems: Linux, Windows, macOS.
  * Supported versions of Python: >= 3.7

--- a/package/debian12/control
+++ b/package/debian12/control
@@ -19,7 +19,7 @@ Description: HDF5 Plugins for windows,MacOS and linux
  hdf5plugin
  ==========
  .
- *hdf5plugin* provides `HDF5 compression filters <https://portal.hdfgroup.org/display/support/Registered+Filter+Plugins>`_ (namely: Blosc, Blosc2, BitShuffle, BZip2, FciDecomp, LZ4, SZ, SZ3, Zfp, ZStd) and makes them usable from `h5py <https://www.h5py.org>`_.
+ *hdf5plugin* provides `HDF5 compression filters <https://portal.hdfgroup.org/documentation/hdf5-docs/registered_filter_plugins.html>`_ (namely: Blosc, Blosc2, BitShuffle, BZip2, FciDecomp, LZ4, SZ, SZ3, Zfp, ZStd) and makes them usable from `h5py <https://www.h5py.org>`_.
  .
  * Supported operating systems: Linux, Windows, macOS.
  * Supported versions of Python: >= 3.7


### PR DESCRIPTION
This PR updates the link to the registered filters on the hdf5 website that was broken