### PR TITLE
Added a release github action workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,159 @@
+name: Build and deploy
+
+on:
+  workflow_dispatch:
+  release:
+    types:
+      - published
+
+jobs:
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+      - name: Build sdist
+        run: python -m build --sdist
+      - name: Check the package
+        run: |
+          python -m twine check dist/*
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz
+
+  test_sdist:
+    needs: [build_sdist]
+    name: Test source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+      - name: Install sdist
+        run: pip install --pre dist/hdf5plugin*.tar.gz
+      - name: Run tests
+        run: python test/test.py
+
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}-${{ matrix.cibw_archs }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Ensure that a wheel builder finishes even if another fails
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-20.04
+            cibw_archs: "auto64"
+            with_sse2: true
+          - os: ubuntu-20.04
+            cibw_archs: "aarch64"
+            with_sse2: false
+          - os: ubuntu-20.04
+            cibw_archs: "ppc64le"
+            with_sse2: false
+          - os: windows-2019
+            cibw_archs: "auto64"
+            with_sse2: true
+          - os: macos-11
+            cibw_archs: "universal2"
+            with_sse2: true
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+        if: runner.os == 'Linux'
+        with:
+          platforms: all
+      - uses: pypa/cibuildwheel@v2.16.2
+        env:
+          # Configure hdf5plugin build
+          HDF5PLUGIN_OPENMP: "False"
+          HDF5PLUGIN_NATIVE: "False"
+          HDF5PLUGIN_SSE2: ${{ matrix.with_sse2 && 'True' || 'False' }}
+          HDF5PLUGIN_AVX2: "False"
+          HDF5PLUGIN_AVX512: "False"
+          HDF5PLUGIN_BMI2: "False"
+          HDF5PLUGIN_CPP11: "True"
+          HDF5PLUGIN_CPP14: "True"
+
+          CIBW_ENVIRONMENT_PASS_LINUX: HDF5PLUGIN_OPENMP HDF5PLUGIN_NATIVE HDF5PLUGIN_SSE2 HDF5PLUGIN_AVX2 HDF5PLUGIN_AVX512 HDF5PLUGIN_BMI2 HDF5PLUGIN_CPP11 HDF5PLUGIN_CPP14
+
+          # Use Python3.11 to build wheels that are compatible with all supported version of Python
+          CIBW_BUILD: cp311-*
+          # Do not build for pypy and muslinux
+          CIBW_SKIP: pp* *-musllinux_*
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+
+          # Use silx wheelhouse for ppc64le
+          CIBW_BEFORE_TEST: pip install h5py --only-binary ":all:" --find-links=https://www.silx.org/pub/wheelhouse/ --trusted-host=www.silx.org
+          CIBW_TEST_COMMAND: python {project}/test/test.py
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
+  test_wheels:
+    needs: [build_wheels]
+    name: Test wheel on ${{ matrix.os }}-${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-2019, macos-11]
+        python-version: ['3.7', '3.12']
+        include:
+          - python-version: '3.7'
+            OLDEST_DEPENDENCIES: 'h5py==2.8.0'
+          - python-version: '3.12'
+            OLDEST_DEPENDENCIES: 'h5py==3.10.0'
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+      - name: Install h5py and hdf5plugin
+        run: |
+          pip install h5py
+          pip install --no-index --no-cache --find-links=./dist hdf5plugin --only-binary hdf5plugin
+      - name: Run test with latest h5py
+        run: python test/test.py
+      - name: Run test with oldest h5py
+        run: |
+          pip install ${{ matrix.OLDEST_DEPENDENCIES }}
+          python test/test.py
+
+  pypi-publish:
+    needs: [build_wheels, build_sdist, test_wheels, test_sdist]
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+    if: github.event_name == 'release' && github.event.action == 'published'
+    # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/src/hdf5plugin/test.py
+++ b/src/hdf5plugin/test.py
@@ -438,6 +438,7 @@ class TestGetFilters(unittest.TestCase):
 class TestSZ(unittest.TestCase):
     """Specific tests for SZ compression"""
 
+    @unittest.skipUnless(should_test("sz"), "SZ filter not available")
     def testAbsoluteMode(self):
         """Test SZ's absolute mode is within required tolerance
 

--- a/test/test.py
+++ b/test/test.py
@@ -223,8 +223,6 @@ class TestHDF5PluginRead(unittest.TestCase):
                              "Values should not be identical")
             self.assertTrue(numpy.allclose(original, output_data, atol=value),
                              "Values should be within tolerance")
-            self.assertTrue(numpy.alltrue(compressed == output_data),
-                             "Compressed data should be identical")
 
             # relative 1E-4
             value = 1E-4
@@ -269,7 +267,10 @@ class TestHDF5PluginRead(unittest.TestCase):
             self.assertTrue(original.shape == compressed.shape, "Incorrect shape")
             self.assertFalse(numpy.alltrue(original == compressed),
                              "Values should not be identical")
-            self.assertTrue(numpy.allclose(compressed, compressed_back),
+            # Absolute error from L2 norm param from:
+            # https://github.com/szcompressor/SZ3/blob/v3.1.8/include/SZ3/utils/Statistic.hpp#L44
+            abs_error = numpy.sqrt(3.0/compressed.ndim) * value
+            self.assertTrue(numpy.allclose(compressed, compressed_back, atol=abs_error),
                              "Compressed read back values should be identical to compressed data")
 
             # create a compressed file
@@ -282,7 +283,7 @@ class TestHDF5PluginRead(unittest.TestCase):
                              "Values should not be identical")
             self.assertTrue(numpy.alltrue(compressed == output_data),
                              "Compressed data should be identical")
-            self.assertTrue(numpy.allclose(compressed_back, output_data),
+            self.assertTrue(numpy.allclose(compressed_back, output_data, atol=abs_error),
                              "Newly L2 norm read back values should be identical to compressed data")
             h5.close()
 


### PR DESCRIPTION
⚠️ Need to sort out PR #290 first (included here so that all tests pass)

The contribution of this PR is commit fef816569c05c43a715bbbd9660091cc5a42bae7

This PR proposes to add github actions workflow to build the wheels and tarball and deploy them to pypi.
The workflow builds wheels for windows (x86_64), macos (x86_64 and arm64) and linux (x86_64, ppc64le and aarch64) using cibuildwheel.

This workflow can be run manually and is run automatically when creating a "release" through github.
When the workflow is started from a "release", the created tarball and wheels are uploaded to pypi, if: build and tests are successful **and** the deployment is manually approved (This still needs some setup on both pypi and github side, but it's no big deal).

Here is a run of this workflow: https://github.com/t20100/hdf5plugin/actions/runs/7639984937/job/20815940046

closes #286