### PR TITLE
Updated c-blosc2 v2.13.1

### DIFF
--- a/doc/information.rst
+++ b/doc/information.rst
@@ -76,7 +76,7 @@ HDF5 compression filters and compression libraries sources were obtained from:
 * `hdf5-blosc plugin <https://github.com/Blosc/hdf5-blosc>`_ (v1.0.0)
   using `c-blosc <https://github.com/Blosc/c-blosc>`_ (v1.21.5), LZ4, Snappy, ZLib and ZStd.
 * hdf5-blosc2 plugin (from `PyTables <https://github.com/PyTables/PyTables/>`_ v3.9.2)
-  using `c-blosc2 <https://github.com/Blosc/c-blosc2>`_ (v2.13.0), LZ4, ZLib and ZStd.
+  using `c-blosc2 <https://github.com/Blosc/c-blosc2>`_ (v2.13.1), LZ4, ZLib and ZStd.
 * `FCIDECOMP plugin <ftp://ftp.eumetsat.int/pub/OPS/out/test-data/Test-data-for-External-Users/MTG_FCI_Test-Data/FCI_Decompression_Software_V1.0.2>`_ (v1.0.2)
   using `CharLS <https://github.com/team-charls/charls>`_
   (1.x branch, commit `25160a4 <https://github.com/team-charls/charls/tree/25160a42fb62e71e4b0ce081f5cb3f8bb73938b5>`_).
@@ -93,9 +93,9 @@ HDF5 compression filters and compression libraries sources were obtained from:
 
 Sources of compression libraries shared accross multiple filters were obtained from:
 
-* `LZ4 v1.9.4 <https://github.com/Blosc/c-blosc2/tree/v2.13.0/internal-complibs/lz4-1.9.4>`_
+* `LZ4 v1.9.4 <https://github.com/Blosc/c-blosc2/tree/v2.13.1/internal-complibs/lz4-1.9.4>`_
 * `Snappy v1.1.10 <https://github.com/google/snappy>`_
-* `ZStd v1.5.5 <https://github.com/Blosc/c-blosc2/tree/v2.13.0/internal-complibs/zstd-1.5.5>`_
+* `ZStd v1.5.5 <https://github.com/Blosc/c-blosc2/tree/v2.13.1/internal-complibs/zstd-1.5.5>`_
 * `ZLib v1.2.13 <https://github.com/Blosc/c-blosc/tree/v1.21.5/internal-complibs/zlib-1.2.13>`_
 
 When compiled with Intel IPP, the LZ4 compression library is replaced with `LZ4 v1.9.3 <https://github.com/lz4/lz4/releases/tag/v1.9.3>`_ patched with a patch from Intel IPP 2021.7.0.

--- a/src/c-blosc2/ANNOUNCE.md
+++ b/src/c-blosc2/ANNOUNCE.md
@@ -1,12 +1,9 @@
-# Announcing C-Blosc2 2.13.0
+# Announcing C-Blosc2 2.13.1
 A fast, compressed and persistent binary data store library for C.
 
 ## What is new?
 
-A new filter for truncating integers has been added. Furthermore, the zstd codec
-has been optimized specially when using dicts. And finally, the grok library
-will be initialized when loading the plugin. This evicts having to import it in 
-some use cases.
+This is a patch release for fixing a bug regarding the included files in `b2nd.h`.
 
 For more info, please see the release notes in:
 

--- a/src/c-blosc2/RELEASE_NOTES.md
+++ b/src/c-blosc2/RELEASE_NOTES.md
@@ -1,6 +1,12 @@
 Release notes for C-Blosc2
 ==========================
 
+Changes from 2.13.0 to 2.13.1
+=============================
+
+* Removed private include in `b2nd.h`. This fixes issue #579.
+
+
 Changes from 2.12.0 to 2.13.0
 =============================
 

--- a/src/c-blosc2/blosc/blosc-private.h
+++ b/src/c-blosc2/blosc/blosc-private.h
@@ -274,45 +274,5 @@ static inline void* load_lib(char *plugin_name, char *libpath) {
   return loaded_lib;
 }
 
-static inline void swap_store(void *dest, const void *pa, int size) {
-  uint8_t *pa_ = (uint8_t *) pa;
-  uint8_t *pa2_ = (uint8_t*)malloc((size_t) size);
-  int i = 1; /* for big/little endian detection */
-  char *p = (char *) &i;
-
-  if (p[0] == 1) {
-    /* little endian */
-    switch (size) {
-      case 8:
-        pa2_[0] = pa_[7];
-        pa2_[1] = pa_[6];
-        pa2_[2] = pa_[5];
-        pa2_[3] = pa_[4];
-        pa2_[4] = pa_[3];
-        pa2_[5] = pa_[2];
-        pa2_[6] = pa_[1];
-        pa2_[7] = pa_[0];
-        break;
-      case 4:
-        pa2_[0] = pa_[3];
-        pa2_[1] = pa_[2];
-        pa2_[2] = pa_[1];
-        pa2_[3] = pa_[0];
-        break;
-      case 2:
-        pa2_[0] = pa_[1];
-        pa2_[1] = pa_[0];
-        break;
-      case 1:
-        pa2_[0] = pa_[0];
-        break;
-      default:
-        fprintf(stderr, "Unhandled nitems: %d\n", size);
-    }
-  }
-  memcpy(dest, pa2_, size);
-  free(pa2_);
-}
-
 
 #endif /* BLOSC_BLOSC_PRIVATE_H */

--- a/src/c-blosc2/blosc/blosc2.c
+++ b/src/c-blosc2/blosc/blosc2.c
@@ -843,11 +843,6 @@ int fill_codec(blosc2_codec *codec) {
     dlclose(lib);
     return BLOSC2_ERROR_FAILURE;
   }
-  if (codec->compcode == BLOSC_CODEC_GROK) {
-    // Initialize grok lib
-    void (*init_func)(uint32_t, bool) = dlsym(lib, "blosc2_grok_init");
-    (*init_func)(0, false);
-  }
 
   return BLOSC2_ERROR_SUCCESS;
 }

--- a/src/c-blosc2/include/b2nd.h
+++ b/src/c-blosc2/include/b2nd.h
@@ -27,7 +27,6 @@ extern "C" {
 #endif
 
 #include "blosc2.h"
-#include "blosc-private.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/c-blosc2/include/blosc2.h
+++ b/src/c-blosc2/include/blosc2.h
@@ -83,10 +83,10 @@ extern "C" {
 /* Version numbers */
 #define BLOSC2_VERSION_MAJOR    2    /* for major interface/format changes  */
 #define BLOSC2_VERSION_MINOR    13   /* for minor interface/format changes  */
-#define BLOSC2_VERSION_RELEASE  0    /* for tweaks, bug-fixes, or development */
+#define BLOSC2_VERSION_RELEASE  1    /* for tweaks, bug-fixes, or development */
 
-#define BLOSC2_VERSION_STRING   "2.13.0"  /* string version.  Sync with above! */
-#define BLOSC2_VERSION_DATE     "$Date:: 2023-01-24 #$"    /* date version */
+#define BLOSC2_VERSION_STRING   "2.13.1"  /* string version.  Sync with above! */
+#define BLOSC2_VERSION_DATE     "$Date:: 2023-01-25 #$"    /* date version */
 
 
 /* The maximum number of dimensions for Blosc2 NDim arrays */
@@ -2503,6 +2503,48 @@ BLOSC_EXPORT void blosc2_multidim_to_unidim(const int64_t *index, int8_t ndim, c
  * detected, a negative code is returned instead.
  */
 BLOSC_EXPORT int blosc2_get_slice_nchunks(blosc2_schunk* schunk, int64_t *start, int64_t *stop, int64_t **chunks_idx);
+
+
+// Private function needed in b2nd.h for deserializing meta
+static inline void swap_store(void *dest, const void *pa, int size) {
+  uint8_t *pa_ = (uint8_t *) pa;
+  uint8_t *pa2_ = (uint8_t*)malloc((size_t) size);
+  int i = 1; /* for big/little endian detection */
+  char *p = (char *) &i;
+
+  if (p[0] == 1) {
+    /* little endian */
+    switch (size) {
+      case 8:
+        pa2_[0] = pa_[7];
+        pa2_[1] = pa_[6];
+        pa2_[2] = pa_[5];
+        pa2_[3] = pa_[4];
+        pa2_[4] = pa_[3];
+        pa2_[5] = pa_[2];
+        pa2_[6] = pa_[1];
+        pa2_[7] = pa_[0];
+        break;
+      case 4:
+        pa2_[0] = pa_[3];
+        pa2_[1] = pa_[2];
+        pa2_[2] = pa_[1];
+        pa2_[3] = pa_[0];
+        break;
+      case 2:
+        pa2_[0] = pa_[1];
+        pa2_[1] = pa_[0];
+        break;
+      case 1:
+        pa2_[0] = pa_[0];
+        break;
+      default:
+        fprintf(stderr, "Unhandled nitems: %d\n", size);
+    }
+  }
+  memcpy(dest, pa2_, size);
+  free(pa2_);
+}
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR updates `c-blosc2` to the latest release [v2.13.1](https://github.com/Blosc/c-blosc2/releases/tag/v2.13.1)