### PR TITLE
Documentation: Fixed typo in `Bitshuffle` docstring

### DIFF
--- a/src/hdf5plugin/_filters.py
+++ b/src/hdf5plugin/_filters.py
@@ -115,8 +115,8 @@ class Bitshuffle(_FilterRefClass):
 
     :param int nelems:
         The number of elements per block.
-        It needs to be divisible by eight (default is 0, about 8kB per block)
-        Default: 0 (for about 8kB per block).
+        It needs to be divisible by eight.
+        Default: 0 (for about 8KB per block).
     :param str cname:
         `lz4` (default), `none`, `zstd`
     :param int clevel: Compression level, used only for `zstd` compression.

--- a/src/hdf5plugin/_filters.py
+++ b/src/hdf5plugin/_filters.py
@@ -116,7 +116,7 @@ class Bitshuffle(_FilterRefClass):
     :param int nelems:
         The number of elements per block.
         It needs to be divisible by eight.
-        Default: 0 (for about 8KB per block).
+        Default: 0 (for about 8 kilobytes per block).
     :param str cname:
         `lz4` (default), `none`, `zstd`
     :param int clevel: Compression level, used only for `zstd` compression.


### PR DESCRIPTION
Remove duplicated information in `Bitshuffle` docstring.