### PR TITLE
avoid throwing ValueError if user sets lz4=False

### DIFF
--- a/src/hdf5plugin/_filters.py
+++ b/src/hdf5plugin/_filters.py
@@ -138,7 +138,7 @@ class Bitshuffle(_FilterRefClass):
         assert clevel <= 22
 
         if lz4 is not None:
-            if cname is not None:
+            if cname is not None and lz4 is not False:
                 raise ValueError("Providing both cname and lz4 arguments is not supported")
             logger.warning(
                 "Deprecation: hdf5plugin.Bitshuffle's lz4 argument is deprecated, "


### PR DESCRIPTION
Just ran into this problem and would like to avoid other users to see a ValueError if they do:

```python
f = h5py.File('test.h5', 'w')
f.create_dataset(
    'bitshuffle_with_lz4',
    data=numpy.arange(100),
    **hdf5plugin.Bitshuffle(nelems=0, lz4=False, cname='zstd'))
f.close()
```