### PR TITLE
Documentation: Fixed broken link, Fixed readthedocs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
   jobs:
     pre_install:
       - echo "HDF5PLUGIN_STRIP=${HDF5PLUGIN_STRIP}"
@@ -24,4 +24,5 @@ python:
    install:
      - method: pip
        path:  .
-       extra_requirements: doc
+       extra_requirements:
+         - doc

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ hdf5plugin
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.7257761.svg
    :target: https://doi.org/10.5281/zenodo.7257761
 
-*hdf5plugin* provides `HDF5 compression filters <https://portal.hdfgroup.org/documentation/hdf5-docs/registered_filter_plugins.html>`_ (namely: Blosc, Blosc2, BitShuffle, BZip2, FciDecomp, LZ4, SZ, SZ3, Zfp, ZStd) and makes them usable from `h5py <https://www.h5py.org>`_.
+*hdf5plugin* provides `HDF5 compression filters <https://github.com/HDFGroup/hdf5_plugins/blob/master/docs/RegisteredFilterPlugins.md#list-of-filters-registered-with-the-hdf-group>`_ (namely: Blosc, Blosc2, BitShuffle, BZip2, FciDecomp, LZ4, Sperr, SZ, SZ3, Zfp, ZStd) and makes them usable from `h5py <https://www.h5py.org>`_.
 
 See `documentation <http://www.silx.org/doc/hdf5plugin/latest/>`_.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,7 +1,7 @@
 hdf5plugin
 ==========
 
-*hdf5plugin* provides `HDF5 compression filters <https://portal.hdfgroup.org/documentation/hdf5-docs/registered_filter_plugins.html>`_ (namely: Blosc, Blosc2, BitShuffle, BZip2, FciDecomp, LZ4, SZ, SZ3, Zfp, ZStd) and makes them usable from `h5py <https://www.h5py.org>`_.
+*hdf5plugin* provides `HDF5 compression filters <https://github.com/HDFGroup/hdf5_plugins/blob/master/docs/RegisteredFilterPlugins.md#list-of-filters-registered-with-the-hdf-group>`_ (namely: Blosc, Blosc2, BitShuffle, BZip2, FciDecomp, LZ4, Sperr, SZ, SZ3, Zfp, ZStd) and makes them usable from `h5py <https://www.h5py.org>`_.
 
 
 * Supported operating systems: Linux, Windows, macOS.


### PR DESCRIPTION
This PR fixes the broken link to HDF5 registered filters and add Sperr to the list of filters