### PR TITLE
Prepare v5.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,9 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
           # Use silx wheelhouse for ppc64le
-          CIBW_BEFORE_TEST: pip install h5py --only-binary ":all:" --find-links=https://www.silx.org/pub/wheelhouse/ --trusted-host=www.silx.org
+          # Use numpy<2 since a wheel for h5py v3.11 which supports numpy v2 is not available for aarch64
+          # see https://github.com/h5py/h5py/issues/2408
+          CIBW_BEFORE_TEST: pip install "numpy<2" h5py --only-binary ":all:" --find-links=https://www.silx.org/pub/wheelhouse/ --trusted-host=www.silx.org
           CIBW_TEST_COMMAND: python {project}/test/test.py
       - uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,39 @@
+5.0.0: 30/08/2024
+-----------------
+
+This release requires Python >= 3.8 (PR #301) and h5py >= 3.0.0 (PR #300).
+
+- Removed deprecated constants: ``hdf5plugin.config``, ``hdf5plugin.date``, ``hdf5plugin.hexversion`` and ``hdf5plugin.strictversion`` (PR #301)
+- Compression filters and libraries:
+
+  * Added **Sperr** filter (PR #303, #322)
+  * Updated filters:
+
+    - **Fcidecomp** (v2.1.1) (PR #311, #320)
+    - **hdf5-blosc** (v1.0.1) (PR #310)
+    - **LZ4** (commit 49e3b65) (PR #310)
+    - **SZ** (commit f466775) (PR #310)
+
+  * Updated libraries:
+
+    - **c-blosc** (v1.21.6) (PR #320)
+    - **c-blosc2** (v2.15.1) (PR #315, #320, #321)
+    - **CharLS** (v2.1.0) (PR #311)
+    - **LZ4** (v1.10.0) (PR #320)
+    - **Snappy** (v1.2.1) (PR #310)
+    - **zlib** (v1.3.1) (PR #320)
+    - **ZStd** (v1.5.6) (PR #315)
+
+  * Fixed **zfp** compilation options for Visual Studio 2022 (PR #313)
+
+- Fixed ``hdf5plugin.Bitshuffle`` to avoid raising ``ValueError`` when ``lz4=False`` (PR #309)
+- Fixed compilation warning on Windows by removing ``/openmp`` link flags (PR #316)
+- Added ``HDF5PLUGIN_CPP20`` build configuration environment variables for **Sperr** (PR #303)
+- Updated ``setup.py`` (PR #298)
+- Updated copyright statement (PR #308)
+- Updated documentation (PR #299, #312, #314, #319)
+- Updated continuous integration configuration (PR #298, #312,#313, #314)
+
 4.4.0: 08/02/2024
 -----------------
 

--- a/src/hdf5plugin/_version.py
+++ b/src/hdf5plugin/_version.py
@@ -26,7 +26,7 @@
 from typing import NamedTuple
 import re
 
-version = "5.0.0a0"
+version = "5.0.0"
 
 
 class _VersionInfo(NamedTuple):


### PR DESCRIPTION
This PR prepares for the release of v5.0.

It bumps the release number and updates the changelog.
It also use `numpy<2` for tests during the release workflow since wheels of h5py v3.11 which supports numpy v2 are not available for `aarch64` and `ppc64le`.