### PR TITLE
Fixed `c-blosc2` compilation issue on `ppc64le`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -940,20 +940,21 @@ def get_blosc2_plugin():
         f'{blosc2_dir}/include',
         f'{blosc2_dir}/plugins/codecs/zfp/include',
     ]
-    define_macros = [
-        ('HAVE_PLUGINS', 1),
-        ('SHUFFLE_SSE2_ENABLED', 1),
-        ('SHUFFLE_AVX2_ENABLED', 1),
-        ('SHUFFLE_AVX512_ENABLED', 1),
-        ('SHUFFLE_NEON_ENABLED', 1),
-        ('SHUFFLE_ALTIVEC_ENABLED', 1),
-    ]
+
+    define_macros = [('HAVE_PLUGINS', 1)]
+    if platform.machine() == 'ppc64le':
+        define_macros.append(('SHUFFLE_ALTIVEC_ENABLED', 1))
+        define_macros.append(('NO_WARN_X86_INTRINSICS', None))
+    else:
+        define_macros.append(('SHUFFLE_SSE2_ENABLED', 1))
+        define_macros.append(('SHUFFLE_AVX2_ENABLED', 1))
+        define_macros.append(('SHUFFLE_AVX512_ENABLED', 1))
+        define_macros.append(('SHUFFLE_NEON_ENABLED', 1))
+
     extra_compile_args = []
     extra_link_args = []
     libraries = []
 
-    if platform.machine() == 'ppc64le':
-        define_macros.append(('NO_WARN_X86_INTRINSICS', None))
     if HostConfig.ARCH == 'ARM_8':
         extra_compile_args += ['-flax-vector-conversions']
     if HostConfig.ARCH == 'ARM_7':


### PR DESCRIPTION
For c-blosc2 on P9, this PR only enables the altivec code and disables all the others.

Otherwise, there is a compilation error:
```
src/c-blosc2/blosc/shuffle.c: In function ‘blosc_get_cpu_features’:
src/c-blosc2/blosc/shuffle.c:272:29: error: ‘HWCAP_ARM_NEON’ undeclared (first use in this function)
  272 |   if (getauxval(AT_HWCAP) & HWCAP_ARM_NEON) {
      |                             ^~~~~~~~~~~~~~
src/c-blosc2/blosc/shuffle.c:272:29: note: each undeclared identifier is reported only once for each function it appears in
error: command '/usr/bin/powerpc64le-linux-gnu-gcc' failed with exit code 1
```

The error was due to trying to compile arm code on P9. This code is now explicitly disabled by changing the defined C macros.