### PR TITLE
CI: Fixed macos build and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             cibw_build: "cp38-manylinux_x86_64"
           - os: windows-2019
             cibw_build: "cp38-win_amd64"
-          - os: macos-12
+          - os: macos-13
             cibw_build: "cp38-macosx_x86_64"
           - os: ubuntu-latest
             cibw_build: "cp310-manylinux_x86_64"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
           - os: windows-2019
             cibw_archs: "auto64"
             with_sse2: true
-          - os: macos-12
+          - os: macos-13
             cibw_archs: "universal2"
             with_sse2: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
         if: runner.os == 'Linux'
         with:
           platforms: all
-      - uses: pypa/cibuildwheel@v2.16.5
+      - uses: pypa/cibuildwheel@v2.22.0
         env:
           # Configure hdf5plugin build
           HDF5PLUGIN_OPENMP: "False"


### PR DESCRIPTION
`macos-12` image is no longer available, switch to `macos-13` (see https://github.com/actions/runner-images/issues/10721)