### PR TITLE
Build: Added `HDF5PLUGIN_SYSTEM_LIBRARIES` env. var. to build using system libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             cibw_build: "cp38-manylinux_x86_64"
           - os: windows-2019
             cibw_build: "cp38-win_amd64"
-          - os: macos-12
+          - os: macos-13
             cibw_build: "cp38-macosx_x86_64"
           - os: ubuntu-latest
             cibw_build: "cp310-manylinux_x86_64"
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: pypa/cibuildwheel@v2.16.5
+      - uses: pypa/cibuildwheel@v2.23.0
         env:
           MACOSX_DEPLOYMENT_TARGET: "10.13"
           CIBW_BUILD_VERBOSITY: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
           - os: windows-2019
             cibw_archs: "auto64"
             with_sse2: true
-          - os: macos-12
+          - os: macos-13
             cibw_archs: "universal2"
             with_sse2: true
 
@@ -79,7 +79,7 @@ jobs:
         if: runner.os == 'Linux'
         with:
           platforms: all
-      - uses: pypa/cibuildwheel@v2.16.5
+      - uses: pypa/cibuildwheel@v2.23.0
         env:
           # Configure hdf5plugin build
           HDF5PLUGIN_OPENMP: "False"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2024 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2025 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -734,7 +734,8 @@ def get_lz4_clib(field=None):
     cflags = ['-O3', '-ffast-math', '-std=gnu99']
     cflags += ['/Ox', '/fp:fast']
 
-    lz4_dir = glob('src/c-blosc2/internal-complibs/lz4*')[0]
+    folders = glob('src/c-blosc2/internal-complibs/lz4*')
+    lz4_dir = folders[0] if folders else "src/no-folder"
 
     config = dict(
         sources=glob(f'{lz4_dir}/*.c'),
@@ -815,7 +816,8 @@ def get_zlib_clib(field=None):
     cflags = ['-O3', '-ffast-math', '-std=gnu99']
     cflags += ['/Ox', '/fp:fast']
 
-    zlib_dir = glob('src/c-blosc/internal-complibs/zlib*')[0]
+    folders = glob('src/c-blosc/internal-complibs/zlib*')
+    zlib_dir = folders[0] if folders else "src/no-folder"
 
     config = dict(
         sources=glob(f'{zlib_dir}/*.c'),
@@ -833,7 +835,8 @@ def get_zstd_clib(field=None):
     cflags = ['-O3', '-ffast-math', '-std=gnu99']
     cflags += ['/Ox', '/fp:fast']
 
-    zstd_dir = glob('src/c-blosc2/internal-complibs/zstd*')[0]
+    folders = glob('src/c-blosc2/internal-complibs/zstd*')
+    zstd_dir = folders[0] if folders else "src/no-folder"
 
     config = dict(
         sources=glob(f'{zstd_dir}/*/*.c'),


### PR DESCRIPTION
This PR reworks the management of C libraries in `setup.py` to:
- Allow to use system libraries instead of embedded sources, closes #324
- Run embedded plugins/libraries configuration code only if they actually are needed, related to #328
- Fix link with dynamic system libs instead of static ones, closes #332