### PR TITLE
Updated compression filer `h5z-sperr` v0.2.3

### DIFF
--- a/doc/information.rst
+++ b/doc/information.rst
@@ -77,7 +77,7 @@ HDF5 compression filters and compression libraries sources were obtained from:
 * `SZ plugin <https://github.com/szcompressor/SZ>`_
   (commit `f466775 <https://github.com/szcompressor/SZ/tree/f4667759ead6a902110e80ff838ccdfddbc8dcd7>`_)
   using `SZ <https://github.com/szcompressor/SZ>`_, ZLib and ZStd.
-* `H5Z-SPERR plugin <https://github.com/NCAR/H5Z-SPERR>`_ (v0.1.3) using `SPERR <https://github.com/NCAR/SPERR>`_ (v0.8.2).
+* `H5Z-SPERR plugin <https://github.com/NCAR/H5Z-SPERR>`_ (v0.2.3) using `SPERR <https://github.com/NCAR/SPERR>`_ (v0.8.2).
 * `SZ3 plugin <https://github.com/szcompressor/SZ3>`_
   (commit `4bbe9df7e4bcb <https://github.com/szcompressor/SZ3/commit/4bbe9df7e4bcb6ae6339fcb3033100da07fe7434>`_)
   using `SZ3 <https://github.com/szcompressor/SZ3>`_ and ZStd.

--- a/setup.py
+++ b/setup.py
@@ -773,12 +773,13 @@ def get_snappy_clib(field=None):
 
 
 def get_sperr_clib(field=None):
-    """sperr static lib build config"""
+    """sperr static lib and sperr filter C++20 source file build config"""
     sperr_dir = "src/SPERR"
+    h5z_sperr_dir = "src/H5Z-SPERR"
 
     config = dict(
-        sources=glob(f"{sperr_dir}/src/*.cpp"),
-        include_dirs=[f"{sperr_dir}/include"],
+        sources=glob(f"{sperr_dir}/src/*.cpp") + [f"{h5z_sperr_dir}/src/h5zsperr_helper.cpp"],
+        include_dirs=BuildConfig.get_hdf5_include_dirs() + [f"{sperr_dir}/include", f"{h5z_sperr_dir}/include"],
         macros=[
             ("SPERR_VERSION_MAJOR", 0),  # Check project(SPERR VERSION ... in src/SPERR/CMakeLists.txt
             ("USE_VANILLA_CONFIG", 1),
@@ -1223,7 +1224,14 @@ def get_sperr_plugin():
 
     return HDF5PluginExtension(
         "hdf5plugin.plugins.libh5sperr",
-        sources=[f"{h5z_sperr_dir}/src/h5z-sperr.c"],
+        sources=prefix(
+            f"{h5z_sperr_dir}/src",
+            [
+                "h5z-sperr.c",
+                "icecream.c",
+                "compactor.c",
+            ]
+        ),
         include_dirs=get_sperr_clib("include_dirs") + [f"{h5z_sperr_dir}/include"],
         extra_link_args=['-lstdc++'],
         define_macros=get_sperr_clib("macros"),

--- a/setup.py
+++ b/setup.py
@@ -786,6 +786,11 @@ def get_sperr_clib(field=None):
         ],
         cflags=["-std=c++20", "/std:c++20"],
     )
+
+    if sys.platform == 'win32':
+        # h5zsperr_helper.cpp is part of the plugin
+        config["macros"].append(('H5_BUILT_AS_DYNAMIC_LIB', None))
+
     if field is None:
         return 'sperr', config
     return config[field]

--- a/src/H5Z-SPERR/.gitignore
+++ b/src/H5Z-SPERR/.gitignore
@@ -1,3 +1,6 @@
+# vim temp files
+*.sw?
+
 # Prerequisites
 *.d
 

--- a/src/H5Z-SPERR/CMakeLists.txt
+++ b/src/H5Z-SPERR/CMakeLists.txt
@@ -1,8 +1,9 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(H5Z-MD5 VERSION 0.1.3 LANGUAGES C DESCRIPTION "HDF5 plugin for SPERR compression")
+project(H5Z-SPERR VERSION 0.2.3 LANGUAGES C CXX DESCRIPTION "HDF5 plugin for SPERR compression")
 
 set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build." FORCE)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "RelWithDebInfo")
@@ -10,6 +11,7 @@ endif()
 
 option( BUILD_SHARED_LIBS "Build shared libraries" ON )
 option( BUILD_CLI_UTILITIES "Build a set of command line utilities" ON )
+option( BUILD_UNIT_TESTS "Build unit tests using GoogleTest" OFF )
 option( H5ZPLUGIN_PREFER_RPATH "Set RPATH; this can fight with package managers 
                                 so turn off when building for them" ON )
 mark_as_advanced(FORCE H5ZPLUGIN_PREFER_RPATH)
@@ -43,10 +45,38 @@ if( BUILD_CLI_UTILITIES )
 endif()
 
 #
+# Build unit tests
+#
+if( BUILD_UNIT_TESTS )
+  # Control internal options of GoogleTest
+  #
+  set( INSTALL_GTEST OFF CACHE INTERNAL "Not install GoogleTest")
+  set( BUILD_GMOCK ON CACHE INTERNAL "Build gmock")
+
+  # Let's use the new mechanism to incorporate GoogleTest
+  #
+  include(FetchContent)
+  if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    FetchContent_Declare( googletest
+      URL https://github.com/google/googletest/archive/refs/heads/main.zip
+      DOWNLOAD_EXTRACT_TIMESTAMP NEW )
+  endif()
+
+  # Prevent overriding the parent project's compiler/linker settings on Windows
+  #
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+  FetchContent_MakeAvailable(googletest)
+
+  enable_testing() # calling this function before adding subdirectory to enable 
+                   # invoking ctest from the top-level build directory.
+  add_subdirectory( test_scripts )
+endif()
+
+#
 # Start installation using GNU installation rules
 #
 include( GNUInstallDirs )
-install( TARGETS h5z-sperr LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} )
+install( TARGETS h5z-sperr h5z-clamp LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} )
 
 if( BUILD_CLI_UTILITIES )
   install( TARGETS generate_cd_values decode_cd_values

--- a/src/H5Z-SPERR/include/compactor.h
+++ b/src/H5Z-SPERR/include/compactor.h
@@ -1,0 +1,74 @@
+/* This is a set of functions that compact a bitmask.
+ * In the intended use case, a bitmask is produced by masking all
+ * "missing values" or "fill values" in a model output with zero's,
+ * whereas the locations with valid data points are marked with one's.
+ * However, this compactor is likely to be effective with any bit patterns
+ * that have lots of consecutive 0's or 1's.
+ *
+ * The bitmask compactor works in the following way:
+ * 1. Assume that we use 32-bit ints; the compactor encodes 32 bits at a time.
+ * 2. Every incoming int is encoded in one of three ways:
+ *    2.1. For an int with all 0's, use a single 0 bit.
+ *    2.2. For an int with all 1's, use two bits: 10.
+ *    2.3. For all other ints, use 34 bits: two bits 11 then followed by the
+ *         verbose presentation of the 32-bit int.
+ * 3. Obviously, it's the most economical to use a single 0 bit to present
+ *    the most frequent pattern (all 0's or all 1's). The encoder thus does
+ *    a test at the beginning and records the test result.
+ */
+
+#ifndef COMPACTOR_H
+#define COMPACTOR_H
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <assert.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Return the compaction strategy to use:
+ * 0: compact with all 0's being the most frequent
+ * 1: compact with all 1's being the most frequent
+ * Note: `bytes` has to be a multiple of 8.
+ */
+int compactor_strategy(const void* buf, size_t bytes);
+
+/* Return the size in bytes of the resulting compacted bitstream, given an input buf.
+ * Note: `buf_bytes` has to be a multiple of 8.
+ */
+size_t compactor_comp_size(const void* buf, size_t buf_bytes);
+
+/* Return the number of useful bytes in a compacted bitstream.
+ * This value is the same as the output of `compactor_comp_size()` during encoding.
+ */
+size_t compactor_useful_bytes(const void* comp_buf);
+
+/* Return the useful size of the output bitstream,
+ * which is the same as the output of `compactor_comp_size()`.
+ * Note 1: the input bitmask length (in bytes) has to be a multiple of 8.
+ *         This requirement is inheritated from the bitstream implementation.
+ * Note 2: the output buffer length should be 1) a multiple of 8, and
+ *         2) no less than the size returned by `compactor_comp_size()`.
+ */
+size_t compactor_encode(const void* bitmask,
+                        size_t bitmask_bytes,
+                        void* compact_bitstream,
+                        size_t compact_bitstream_bytes);
+
+/* Return the number of useful bytes in the decoded bitmask.
+ * Note: The number of useful bytes might be bigger than the number of bytes being
+ *       encoded, because of the word size that the compactor operates on.
+ * Note: `compact_bitstream_bytes` should be a multiple of 8 that is no less than
+ *       the size returned by `compactor_encode()`.
+ */
+size_t compactor_decode(const void* compact_bitstream,
+                        size_t compact_bitstream_bytes,
+                        void* decoded_bitmask);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/H5Z-SPERR/include/h5zsperr_helper.h
+++ b/src/H5Z-SPERR/include/h5zsperr_helper.h
@@ -1,0 +1,61 @@
+/*
+ * This file contains a few helper functions for the H5Z-SPERR filter.
+ */
+
+#ifndef H5ZSPERR_HELPER_H
+#define H5ZSPERR_HELPER_H
+
+#include <stdlib.h>
+
+#define LARGE_MAGNITUDE_F 1e35f
+#define LARGE_MAGNITUDE_D 1e35
+#define H5ZSPERR_COMPATIBILITY 1
+
+#ifdef __cplusplus
+namespace C_API {
+extern "C" {
+#endif
+
+/*
+ * Pack and unpack additional information about the input data into an integer.
+ * It returns the encoded unsigned int, which shouldn't be zero.
+ * The packing function is called by `set_local()` to prepare information
+ * for `H5Z_filter_sperr()`, which calls the unpack function to extract such info.
+ */
+unsigned int h5zsperr_pack_extra_info(int rank, int is_float, int missing_val_mode, int magic_num);
+void h5zsperr_unpack_extra_info(unsigned int meta,
+                                int* rank,
+                                int* is_float,
+                                int* missing_val_mode,
+                                int* magic_num);
+
+/*
+ * Check if an input array really has missing values.
+ */
+int h5zsperr_has_nan(const void* buf, size_t nelem, int is_float);
+int h5zsperr_has_large_mag(const void* buf, size_t nelem, int is_float);
+
+/*
+ * Produce a compact bitmask.
+ * `mask_buf` is already allocated with length `mask_bytes`.
+ * Returns 0 upon success.
+ */
+int h5zsperr_make_mask_nan(const void* data_buf, size_t nelem, int is_float,
+                           void* mask_buf, size_t mask_bytes, size_t* useful_bytes);
+int h5zsperr_make_mask_large_mag(const void* data_buf, size_t nelem, int is_float,
+                                 void* mask_buf, size_t mask_bytes, size_t* useful_bytes);
+
+/*
+ * Replace every missing value in the `data_buf` with the mean of the field.
+ */
+float h5zsperr_treat_nan_f32(float* data_buf, size_t nelem);
+double h5zsperr_treat_nan_f64(double* data_buf, size_t nelem);
+float h5zsperr_treat_large_mag_f32(float* data_buf, size_t nelem);
+double h5zsperr_treat_large_mag_f64(double* data_buf, size_t nelem);
+
+#ifdef __cplusplus
+} /* end of extern "C" */
+} /* end of namespace C_API */
+#endif
+
+#endif

--- a/src/H5Z-SPERR/include/icecream.h
+++ b/src/H5Z-SPERR/include/icecream.h
@@ -1,0 +1,64 @@
+/*
+ * This is a mimic of the Bitstream class in SPERR:
+ * https://github.com/NCAR/SPERR/blob/main/include/Bitstream.h
+ *
+ * The most significant difference is that bitstream here doesn't manage
+ * any memory; it reads a bit sequence from a user-provided memory buffer,
+ * or writes a bit sequence to a user-provided memory buffer.
+ * 
+ * The "object" is named `icecream` and all functions operating on it
+ * are named with a prefix `icecream`.
+ */
+
+#ifndef ICECREAM_H
+#define ICECREAM_H
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <assert.h>
+
+#ifndef NDEBUG
+#include <stdio.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  uint64_t* begin;  /* begin of the stream */
+  uint64_t* ptr;    /* pointer to the next word to be read/written */
+  uint64_t  buffer; /* incoming/outgoing bits */
+  int       bits;   /* number of buffered bits (0 <= bits < 64) */
+} icecream;
+
+/*
+ * Specify a bitstream to use memory provided by users.
+ * NOTE: the memory length (in bytes) have to be a multiplier of 8,
+ * because the icecream class writes/reads in 64-bit integers.
+ */
+void icecream_use_mem(icecream* s, void* mem, size_t bytes);
+
+/* Position the bitstream for reading or writing at the beginning. */
+void icecream_rewind(icecream* s);
+
+/* Read a bit. Please don't read beyond the end of the stream. */
+int icecream_rbit(icecream* s);
+
+/* Write a bit (0 or 1). Please don't write beyond the end of the stream. */
+void icecream_wbit(icecream* s, int bit);
+
+/* Return the bit offset to the next bit to be read. */
+size_t icecream_rtell(icecream* s);
+
+/* Return the bit offset to the next bit to be written. */
+size_t icecream_wtell(icecream* s);
+
+/* Write any remaining buffered bits and align stream on next word boundary. */
+void icecream_flush(icecream* s);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/H5Z-SPERR/src/CMakeLists.txt
+++ b/src/H5Z-SPERR/src/CMakeLists.txt
@@ -1,5 +1,18 @@
-add_library( h5z-sperr h5z-sperr.c )
+#
+# The main H5Z-SPERR filter
+#
+add_library( h5z-sperr h5z-sperr.c
+                       h5zsperr_helper.cpp
+                       icecream.c
+                       compactor.c)
 target_include_directories( h5z-sperr PUBLIC ${HDF5_INCLUDE_DIR} 
                                       PUBLIC ${SPERR_INCLUDE_DIRS}
                                       PUBLIC ${CMAKE_SOURCE_DIR}/include )
 target_link_libraries( h5z-sperr PUBLIC ${HDF5_LIBRARIES} PUBLIC PkgConfig::SPERR )
+
+#
+# Experimental clamping filter
+#
+add_library( h5z-clamp h5z-clamp.c )
+target_include_directories( h5z-clamp PUBLIC ${HDF5_INCLUDE_DIR} )
+target_link_libraries( h5z-clamp PUBLIC ${HDF5_LIBRARIES} )

--- a/src/H5Z-SPERR/src/compactor.c
+++ b/src/H5Z-SPERR/src/compactor.c
@@ -1,0 +1,186 @@
+#include "compactor.h"
+#include "icecream.h"
+#include <assert.h>
+#include <string.h> /* memcpy() */
+
+#ifndef NDEBUG
+#include <stdio.h>
+#endif
+
+/*
+ * Change this typedef to use a different width.
+ * Though only uint32_t is tested so far.
+ */
+typedef uint32_t INT;
+
+int compactor_strategy(const void* buf, size_t bytes)
+{
+  assert(bytes % 8 == 0);
+  const INT all0 = 0;
+  const INT all1 = ~all0;
+  const INT* p = (const INT*)buf;
+
+  size_t n0 = 0, n1 = 0;
+  for (size_t i = 0; i < bytes / sizeof(INT); i++) {
+    INT v = p[i];
+    n0 += (v == all0);
+    n1 += (v == all1);
+  }
+
+  return n1 > n0;
+}
+
+size_t compactor_comp_size(const void* buf, size_t bytes)
+{
+  /* The compacted bitstream has the following format:
+   * -- 32 bits indicating the total number of useful bits
+   * -- a single bit indicating the compaction strategy;
+   * -- a bitstream encoding every INT;
+   */
+  assert(bytes % 8 == 0);
+
+  const INT all0 = 0;
+  const INT all1 = ~all0;
+  const INT* p = (const INT*)buf;
+
+  size_t n0 = 0, n1 = 0;
+  for (size_t i = 0; i < bytes / sizeof(INT); i++) {
+    INT v = p[i];
+    n0 += (v == all0);
+    n1 += (v == all1);
+  }
+  /* INTs need to be encoded verbosely */
+  size_t nverb = bytes / sizeof(INT) - n0 - n1;
+
+  size_t nbits = 33;
+  if (n0 >= n1) {
+    nbits += n0;
+    nbits += n1 * 2;
+  }
+  else {
+    nbits += n1;
+    nbits += n0 * 2;
+  }
+  nbits += nverb * (2 + 8 * sizeof(INT));
+
+  size_t nbytes = (nbits + 7) / 8;
+  return nbytes;
+}
+
+size_t compactor_useful_bytes(const void* comp_buf)
+{
+  uint32_t nbits = 0;
+  memcpy(&nbits, comp_buf, sizeof(nbits));
+
+  return (nbits + 7) / 8;
+}
+
+size_t compactor_encode(const void* bitmask,
+                        size_t bitmask_bytes,
+                        void* compact_bitstream,
+                        size_t compact_bitstream_bytes)
+{
+  assert(bitmask_bytes % 8 == 0);
+  assert(compact_bitstream_bytes % 8 == 0);
+
+  /* decide on the compaction strategy */
+  INT most_freq = 0;
+  INT next_freq = ~most_freq;
+  int strategy = compactor_strategy(bitmask, bitmask_bytes);
+  if (strategy) {
+    next_freq = 0;
+    most_freq = ~next_freq;
+  }
+
+  icecream out;
+  icecream_use_mem(&out, compact_bitstream, compact_bitstream_bytes);
+
+  /* skip 32 bits for total bit count storage, and then keep the strategy. */
+  for (int i = 0; i < 32; i++)
+    icecream_wbit(&out, 0);
+  icecream_wbit(&out, strategy);
+
+  /* encode the bitmask, one INT at a time */
+  const INT* p = (const INT*)bitmask;
+  for (size_t i = 0; i < bitmask_bytes / sizeof(INT); i++) {
+    INT v = p[i];
+    if (v == most_freq)
+      icecream_wbit(&out, 0);
+    else if (v == next_freq) {
+      icecream_wbit(&out, 1);
+      icecream_wbit(&out, 0);
+    }
+    else {
+      icecream_wbit(&out, 1);
+      icecream_wbit(&out, 1);
+      for (int j = 0; j < 8 * sizeof(INT); j++) {
+        int bit = (v >> j) & (INT)1;
+        icecream_wbit(&out, bit);
+      }
+    }
+  }
+
+  size_t nbits = icecream_wtell(&out);
+  icecream_flush(&out);
+
+  /* make sure that the total number of bits can fit in a 32-bit integer,
+   * and keep it at the beginning of the output bitstream. */
+  uint32_t tmp = 0;
+  assert(nbits <= ~tmp);
+  tmp = (uint32_t)nbits;
+  memcpy(compact_bitstream, &tmp, sizeof(tmp));
+
+  return (nbits + 7) / 8;
+}
+
+size_t compactor_decode(const void* compact_bitstream,
+                        size_t compact_bitstream_bytes,
+                        void* decoded_bitmask)
+{
+  assert(compact_bitstream_bytes % 8 == 0);
+
+  /* wrap the `compact_bitstream` in an icecream. As long as we don't write,
+   * its content won't be changed. */ 
+  icecream in;
+  icecream_use_mem(&in, (void*)compact_bitstream, compact_bitstream_bytes);
+
+  /* extract the total number of useful bits, then skip the first 32 bits. */
+  uint32_t nbits = 0;
+  memcpy(&nbits, compact_bitstream, sizeof(nbits));
+  for (int i = 0; i < 32; i++)
+    icecream_rbit(&in);
+
+  /* decide on the compaction strategy. */
+  INT most_freq = 0;
+  INT next_freq = ~most_freq;
+  int strategy = icecream_rbit(&in);
+  if (strategy) {
+    next_freq = 0;
+    most_freq = ~next_freq;
+  }
+
+  /* decode the bitmask one INT at a time */
+  INT* p = (INT*)decoded_bitmask;
+  while (icecream_rtell(&in) < nbits) {
+    int bit = icecream_rbit(&in);
+    if (bit == 0)   /* produce a most frequent INT */
+      *p++ = most_freq;
+    else {
+      assert(icecream_rtell(&in) < nbits);
+      bit = icecream_rbit(&in);
+      if (bit == 0) /* produce a second most frequent INT */
+        *p++ = next_freq;
+      else {        /* read the next INT verbosely */
+        INT v = 0;
+        for (int j = 0; j < 8 * sizeof(INT); j++) {
+          assert(icecream_rtell(&in) < nbits);
+          bit = icecream_rbit(&in);
+          v |= (INT)bit << j;
+        }
+        *p++ = v;
+      }
+    }
+  }
+
+  return (p - (INT*)decoded_bitmask) * sizeof(INT);
+}

--- a/src/H5Z-SPERR/src/h5z-clamp.c
+++ b/src/H5Z-SPERR/src/h5z-clamp.c
@@ -1,0 +1,127 @@
+/*
+ * This file contains the clamp filter class definition, H5Z_clamp_class_t,
+ * and necessary functions required by the HDF5 plugin architecture:
+ * - can_apply()
+ * - set_local()
+ * - filter()
+ * - get_plugin_info()
+ * - get_plugin_type()
+ */
+
+#define H5Z_FILTER_CLAMP 45678
+
+#include <assert.h>
+#include <stdlib.h>
+
+#include <H5PLextern.h>
+#include <hdf5.h>
+
+static htri_t H5Z_can_apply_clamp(hid_t dcpl_id, hid_t type_id, hid_t space_id)
+{
+  /*
+   * 	dcpl_id	  Dataset creation property list identifier
+   * 	type_id	  Datatype identifier
+   * 	space_id  Dataspace identifier
+   */
+
+  /* Get datatype class. Fail if not floats. */
+  if (H5Tget_class(type_id) != H5T_FLOAT) {
+    H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADTYPE,
+            "bad data type. Only floats are supported in H5Z-CLAMP");
+    return 0;
+  }
+  size_t type_size = H5Tget_size(type_id);
+  assert(type_size == 4 || type_size == 8);
+
+  return 1;
+}
+
+static herr_t H5Z_set_local_clamp(hid_t dcpl_id, hid_t type_id, hid_t space_id)
+{
+  /*
+   * 	dcpl_id	  Dataset creation property list identifier
+   * 	type_id	  Datatype identifier
+   * 	space_id  Dataspace identifier
+   */
+
+  /* Get the datatype size. It must be 4 or 8, since the float type is verified by `can_apply`. */
+  unsigned int is_float = H5Tget_size(type_id) == 4 ? 1 : 0;
+
+  /*
+   * Assemble the meta info to be stored.
+   * [0] : float/double
+   */
+  size_t cd_nelems = 1;
+  unsigned int cd_values[1] = {is_float};
+  H5Pmodify_filter(dcpl_id, H5Z_FILTER_CLAMP, H5Z_FLAG_MANDATORY, cd_nelems, cd_values);
+
+  return 1;
+}
+
+static size_t H5Z_filter_clamp(unsigned int flags,
+                               size_t cd_nelmts,
+                               const unsigned int cd_values[],
+                               size_t nbytes,
+                               size_t* buf_size,
+                               void** buf)
+{
+  int is_float = cd_values[0];
+  assert(is_float == 1 || is_float == 0);
+
+  if (flags & H5Z_FLAG_REVERSE) { /* Decompression */
+
+    if (is_float) {
+      if (nbytes % 4) {
+        H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADSIZE,
+                "Decompression: input buffer len isn't right.");
+        return 0;
+      }
+      const size_t nelem = nbytes / 4;
+      float* p = (float*)(*buf);
+      for (size_t i = 0; i < nelem; i++) {
+        if (p[i] < 0.f)
+          p[i] = 0.f;
+      }
+    }
+    else {
+      if (nbytes % 8) {
+        H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADSIZE,
+                "Decompression: input buffer len isn't right.");
+        return 0;
+      }
+      const size_t nelem = nbytes / 8;
+      double* p = (double*)(*buf);
+      for (size_t i = 0; i < nelem; i++) {
+        if (p[i] < 0.0)
+          p[i] = 0.0;
+      }
+    }
+
+    return *buf_size;
+
+  }      /* Finish Decompression */
+  else { /* Compression */
+
+    /* Nothing to be done during compression :) */
+    return *buf_size;
+  }
+}
+
+const H5Z_class2_t H5Z_clamp_class_t = {H5Z_CLASS_T_VERS, /* H5Z_class_t version */
+                                        H5Z_FILTER_CLAMP, /* Filter id number    */
+                                        1,                /* encoder_present flag (set to true) */
+                                        1,                /* decoder_present flag (set to true) */
+                                        "H5Z-CLAMP",      /* Filter name for debugging  */
+                                        H5Z_can_apply_clamp, /* The "can apply" callback   */
+                                        H5Z_set_local_clamp, /* The "set local" callback   */
+                                        H5Z_filter_clamp};   /* The actual filter function */
+
+const void* H5PLget_plugin_info()
+{
+  return &H5Z_clamp_class_t;
+}
+
+H5PL_type_t H5PLget_plugin_type()
+{
+  return H5PL_TYPE_FILTER;
+}

--- a/src/H5Z-SPERR/src/h5z-sperr.c
+++ b/src/H5Z-SPERR/src/h5z-sperr.c
@@ -1,3 +1,13 @@
+/*
+ * This file contains the SPERR filter class definition, H5Z_SPERR_class_t,
+ * and necessary functions required by the HDF5 plugin architecture:
+ * - can_apply()
+ * - set_local()
+ * - filter()
+ * - get_plugin_info()
+ * - get_plugin_type()
+ */
+
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
@@ -7,6 +17,9 @@
 
 #include <SPERR_C_API.h>
 #include "h5z-sperr.h"
+#include "h5zsperr_helper.h"
+#include "compactor.h"
+#include "icecream.h"
 
 #ifndef NDEBUG
 #include <stdio.h>
@@ -17,7 +30,7 @@ static htri_t H5Z_can_apply_sperr(hid_t dcpl_id, hid_t type_id, hid_t space_id)
   /*
    * 	dcpl_id	  Dataset creation property list identifier
    * 	type_id	  Datatype identifier
-   * 	space_id	Dataspace identifier
+   * 	space_id  Dataspace identifier
    */
 
   /* Get datatype class. Fail if not floats. */
@@ -39,6 +52,10 @@ static htri_t H5Z_can_apply_sperr(hid_t dcpl_id, hid_t type_id, hid_t space_id)
     return 0;
   }
 
+  /* Get the dataspace dimension. */
+  hsize_t dspace_dims[4] = {0, 0, 0, 0};
+  ndims = H5Sget_simple_extent_dims(space_id, dspace_dims, NULL);
+
   /* Chunks have to be 2D, 3D, or 4D as well. */
   hsize_t chunks[4] = {0, 0, 0, 0};
   ndims = H5Pget_chunk(dcpl_id, 4, chunks);
@@ -52,7 +69,19 @@ static htri_t H5Z_can_apply_sperr(hid_t dcpl_id, hid_t type_id, hid_t space_id)
     return 0;
   }
 
-  /* Find out the real dimension. */
+  /* Dataspace dimension must be divisible by the chunk dimension. */
+  for (int i = 0; i < ndims; i++)
+    if (dspace_dims[i] % chunks[i]) {
+#ifndef NDEBUG
+      printf("%s: %d, dataspace dim = %llu, chunk dim = %llu\n", __FILE__, __LINE__, dspace_dims[i],
+             chunks[i]);
+#endif
+      H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADTYPE,
+              "bad chunk size. The dataspace dimensions must be divisible by the chunk dimension");
+      return 0;
+    }
+
+  /* Find out the real dimension (of each chunk). */
   int real_dims = 0;
   for (int i = 0; i < 4; i++)
     if (chunks[i] > 1)
@@ -82,96 +111,88 @@ static htri_t H5Z_can_apply_sperr(hid_t dcpl_id, hid_t type_id, hid_t space_id)
   return 1;
 }
 
-/*
- * Pack information about the input data into an `unsigned int`.
- * It returns the encoded unsigned int, which shouldn't be zero.
- */
-static unsigned int H5Z_SPERR_pack_data_type(int rank,  /* Input */
-                                             int dtype) /* Input */
-{
-  unsigned int ret = 0;
-
-  /*
-   * Bit position 0-3 to encode the rank.
-   * Since this function is called from `set_local()`, it should always be 2 or 3.
-   */
-  if (rank == 2) {
-    ret |= 1u << 1; /* Position 1 */
-  }
-  else {
-    assert(rank == 3);
-    ret |= 1u;      /* Position 0 */
-    ret |= 1u << 1; /* Position 1 */
-  }
-
-  /*
-   * Bit position 4-7 encode data type.
-   * Only float (1) and double (0) are supported right now.
-   */
-  if (dtype == 1)   /* is_float   */
-    ret |= 1u << 4; /* Position 4 */
-  else
-    assert(dtype == 0);
-
-  return ret;
-}
-
-/*
- * Unpack information about the input data from an `unsigned int`.
- */
-static void H5Z_SPERR_unpack_data_type(unsigned int meta, /* Input  */
-                                       int* rank,         /* Output */
-                                       int* dtype)        /* Output */
-{
-  /*
-   * Extract rank from bit positions 0-3.
-   */
-  unsigned pos0 = meta & 1u;
-  unsigned pos1 = meta & (1u << 1);
-  if (!pos0 && pos1)
-    *rank = 2;
-  else if (pos0 && pos1)
-    *rank = 3;
-  else { /* error */
-    H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADVALUE,
-            "Rank is not 2 or 3.");
-  }
-
-  /*
-   * Extract data type from position 4-7.
-   * Only float and double are supported right now.
-   */
-  unsigned pos4 = meta & (1u << 4);
-  if (pos4)
-    *dtype = 1; /* is_float  */
-  else
-    *dtype = 0; /* is_double */
-}
-
 static herr_t H5Z_set_local_sperr(hid_t dcpl_id, hid_t type_id, hid_t space_id)
 {
   /*
    * 	dcpl_id	  Dataset creation property list identifier
    * 	type_id	  Datatype identifier
-   * 	space_id	Dataspace identifier
+   * 	space_id  Dataspace identifier
    */
 
-  /* Get the user-specified compression mode and quality. */
-  size_t user_cd_nelem = 2;
-  unsigned int user_cd_values[2] = {0, 0}; /* !! The same length as `user_cd_nelem` specified !! */
+  /*
+   * Get the user-specified parameters. It has mandatory and optional fields.
+   * -- One integer (mandatory): compression mode, quality, rank swap
+   * -- One integer (optional) : missing value mode
+   * -- One/two integers (optional): a float or double specifying the missing value
+   *    (not implemented)
+   */
+  size_t user_cd_nelem = 4; /* the maximum possible number */
+  unsigned int user_cd_values[4] = {0, 0, 0, 0};
   char name[16];
   for (size_t i = 0; i < 16; i++)
     name[i] = ' ';
-  unsigned int flags = 0;
-  herr_t status =
-      H5Pget_filter_by_id(dcpl_id, H5Z_FILTER_SPERR, &flags, &user_cd_nelem, user_cd_values, 16,
-                          name, user_cd_values + user_cd_nelem - 1);
-  if (user_cd_nelem != 1) {
+  unsigned int flags = 0, filter_config = 0;
+  herr_t status = H5Pget_filter_by_id(dcpl_id, H5Z_FILTER_SPERR, &flags, &user_cd_nelem,
+                                      user_cd_values, 16, name, &filter_config);
+
+  /*
+   * `missing_val_mode` meaning:
+   * 0: no missing value
+   * 1: any NAN is a missing value
+   * 2: any value where abs(value) >= 1e35 is a missing value.
+   * 3: use a single 32-bit float as the missing value. (not implemented)
+   * 4: use a single 64-bit double as the missing value. (not implemented)
+   */
+  int missing_val_mode = 0;
+  if (user_cd_nelem == 1) {
+    missing_val_mode = 0;
+  }
+  else if (user_cd_nelem == 2) {
+    missing_val_mode = user_cd_values[1];
+    if (missing_val_mode > 2) {
+#ifndef NDEBUG
+      printf("%s: %d, user_cd_nelem = %lu\n", __FILE__, __LINE__, user_cd_nelem);
+#endif
+      H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADSIZE,
+              "User cd_values[] isn't valid.");
+      return -1;
+    }
+  }
+
+/* Mode 3 and 4 are not implemented. */
+#if 0
+  else if (user_cd_nelem == 3) {
+    missing_val_mode = user_cd_values[1];
+    if (missing_val_mode != 3) {
+#ifndef NDEBUG
+      printf("%s: %d, user_cd_nelem = %lu\n", __FILE__, __LINE__, user_cd_nelem);
+#endif
+      H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADSIZE,
+              "User cd_values[] isn't valid.");
+      return -1;
+    }
+    memcpy(&missing_val_f, &user_cd_values[2], sizeof(missing_val_f));
+  }
+  else if (user_cd_nelem == 4) {
+    missing_val_mode = user_cd_values[1];
+    if (missing_val_mode != 4) {
+#ifndef NDEBUG
+      printf("%s: %d, user_cd_nelem = %lu\n", __FILE__, __LINE__, user_cd_nelem);
+#endif
+      H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADSIZE,
+              "User cd_values[] isn't valid.");
+      return -1;
+    }
+    memcpy(&missing_val_d, &user_cd_values[2], sizeof(missing_val_d));
+  }
+#endif
+
+  else {
 #ifndef NDEBUG
     printf("%s: %d, user_cd_nelem = %lu\n", __FILE__, __LINE__, user_cd_nelem);
 #endif
     H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADSIZE,
-            "User cd_values[] isn't a single element ??");
+            "User cd_values[] has more than 4 elements.");
     return -1;
   }
 
@@ -193,13 +214,15 @@ static herr_t H5Z_set_local_sperr(hid_t dcpl_id, hid_t type_id, hid_t space_id)
 
   /*
    * Assemble the meta info to be stored.
-   * [0]  : 2D/3D, float/double
-   * [1]  : compression specifics
+   * [0]  : 2D/3D, float/double, missing_val_mode, magic_number
+   * [1]  : compression specifics (user input)
    * [2-3]: (dimx, dimy) in 2D cases.
    * [2-4]: (dimx, dimy, dimz) in 3D cases.
+   * Followed by 0, 1, or 2 integers storing the exact missing value. (not implemented)
    */
-  unsigned int cd_values[5] = {0, 0, 0, 0, 0};
-  cd_values[0] = H5Z_SPERR_pack_data_type(real_dims, is_float);
+  unsigned int cd_values[7] = {0, 0, 0, 0, 0, 0, 0};
+  cd_values[0] =
+      h5zsperr_pack_extra_info(real_dims, is_float, missing_val_mode, H5ZSPERR_COMPATIBILITY);
   cd_values[1] = user_cd_values[0];
   int i1 = 2, i2 = 0;
   while (i2 < 4) {
@@ -207,12 +230,25 @@ static herr_t H5Z_set_local_sperr(hid_t dcpl_id, hid_t type_id, hid_t space_id)
       cd_values[i1++] = (unsigned int)chunks[i2];
     i2++;
   }
-  if (real_dims == 2)
-    H5Pmodify_filter(dcpl_id, H5Z_FILTER_SPERR, H5Z_FLAG_MANDATORY, 4, cd_values);
-  else
-    H5Pmodify_filter(dcpl_id, H5Z_FILTER_SPERR, H5Z_FLAG_MANDATORY, 5, cd_values);
 
-  return 0;
+  /* figure out the length of cd_values[] */
+  size_t cd_nelems = (real_dims == 2) ? 4 : 5;
+
+  /* Mode 3 and 4 are not implemented. */
+#if 0
+  if (missing_val_mode == 3) { /* a specific float */
+    cd_nelems += 1;
+    memcpy(&cd_values[i1], &missing_val_f, sizeof(missing_val_f));
+  }
+  else if (missing_val_mode == 4) { /* a specific double */
+    cd_nelems += 2;
+    memcpy(&cd_values[i1], &missing_val_d, sizeof(missing_val_d));
+  }
+#endif
+
+  H5Pmodify_filter(dcpl_id, H5Z_FILTER_SPERR, H5Z_FLAG_MANDATORY, cd_nelems, cd_values);
+
+  return 1;
 }
 
 static size_t H5Z_filter_sperr(unsigned int flags,
@@ -223,58 +259,157 @@ static size_t H5Z_filter_sperr(unsigned int flags,
                                void** buf)
 {
   /* Extract info from cd_values[] */
-  int rank = 0, is_float = 0;
-  H5Z_SPERR_unpack_data_type(cd_values[0], &rank, &is_float);
-  if ((rank == 2 && cd_nelmts != 4) || (rank == 3 && cd_nelmts != 5)) {
-#ifndef NDEBUG
-    printf("rank = %d, cd_nelmts = %lu\n", rank, cd_nelmts);
-#endif
+  int rank = 0, is_float = 0, missing_val_mode = 0, magic = 0;
+  h5zsperr_unpack_extra_info(cd_values[0], &rank, &is_float, &missing_val_mode, &magic);
+  assert(rank == 2 || rank == 3);
+  assert(is_float == 0 || is_float == 1);
+  assert(missing_val_mode >= 0 && missing_val_mode <= 2);
+  assert(cd_nelmts == (rank == 2 ? 4 : 5));
+
+  /* Support binaries from one generation back. */
+  if (magic < H5ZSPERR_COMPATIBILITY - 1 || magic > H5ZSPERR_COMPATIBILITY) {
     H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADVALUE,
-            "SPERR filter cd_values[] length not correct.");
+            "This file is produced by H5Z-SPERR of a different compatibility version.");
     return 0;
   }
 
-  int mode = 0, swap = 0;
+  int comp_mode = 0, swap = 0;
   double quality = 0.0;
-  H5Z_SPERR_decode_cd_values(cd_values[1], &mode, &quality, &swap);
+  H5Z_SPERR_decode_cd_values(cd_values[1], &comp_mode, &quality, &swap);
   unsigned int dims[3] = {cd_values[2], cd_values[3], rank == 2 ? 1 : cd_values[4]};
   if (swap) {
+    unsigned int tmp = dims[0];
     if (rank == 2) {
-      unsigned int tmp = dims[0];
       dims[0] = dims[1];
       dims[1] = tmp;
     }
     else {
-      unsigned int tmp = dims[0];
       dims[0] = dims[2];
       dims[2] = tmp;
     }
   }
 
-  /* Decompression */
-  if (flags & H5Z_FLAG_REVERSE) {
+  if (flags & H5Z_FLAG_REVERSE) { /* Decompression */
+
+    const size_t nelem = (size_t)dims[0] * dims[1] * dims[2];
+    const uint8_t* p = (uint8_t*)(*buf);
+
+    /*
+     * Since version 0.2.x, the real missing mode is explicitly stored in the first byte.
+     * However, there's no such byte storage in version 0.1.x. To be able to read binaries
+     * produced by 0.1.x, in such cases (magic == 0), real_missing_mode is always 0,
+     * and there's no byte offset.
+     * Can remove this logic when dropping support for 0.1.x.
+     */
+    int real_missing_mode = p[0];
+    size_t offset = 1;
+    if (magic == 0) {
+      real_missing_mode = 0;
+      offset = 0;
+    }
+
+    /* Save the fill value. */
+    float fill_val_f = 0.f;
+    double fill_val_d = 0.0;
+    if (real_missing_mode == 2) {
+      if (is_float)
+        memcpy(&fill_val_f, p + offset, sizeof(fill_val_f));
+      else
+        memcpy(&fill_val_d, p + offset, sizeof(fill_val_d));
+      offset += is_float ? 4 : 8;
+    }
+
+    /* Decode the bitmask. */
+    void* mask = NULL; /* naive bitmask */
+    size_t mask_bytes = 0;
+    if (real_missing_mode != 0) {
+      mask_bytes = (nelem + 7) / 8;
+      while (mask_bytes % 8)
+        mask_bytes++;
+      mask = malloc(mask_bytes);
+
+      size_t compact_bytes = compactor_useful_bytes(p + offset);
+      while (compact_bytes % 8)
+        compact_bytes++;
+
+      compactor_decode(p + offset, compact_bytes, mask);
+      offset += compactor_useful_bytes(p + offset);
+    }
+
+    /* Decompress the real data. */
     void* dst = NULL; /* buffer to hold the decompressed data */
+    size_t dst_len = (is_float ? 4ul : 8ul) * nelem;
     int ret = 0;
     if (rank == 2)
-      ret = sperr_decomp_2d(*buf, nbytes, is_float, dims[0], dims[1], &dst);
+      ret = sperr_decomp_2d(p + offset, nbytes - offset, is_float, dims[0], dims[1], &dst);
     else {
       size_t dimx = 0, dimy = 0, dimz = 0;
-      ret = sperr_decomp_3d(*buf, nbytes, is_float, 1, &dimx, &dimy, &dimz, &dst);
+      ret = sperr_decomp_3d(p + offset, nbytes - offset, is_float, 1, &dimx, &dimy, &dimz, &dst);
+      assert(dimx == dims[0]);
+      assert(dimy == dims[1]);
+      assert(dimz == dims[2]);
     }
-    if (ret != 0) {
+    if (ret) {
       if (dst) {
-        free(dst); /* allocated by SPERR, using malloc() */
+        free(dst);
         dst = NULL;
+      }
+      if (mask) {
+        free(mask);
+        mask = NULL;
       }
       H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADVALUE,
               "SPERR decompression failed.");
       return 0;
     }
 
-    size_t dst_len = (is_float ? 4ul : 8ul) * dims[0] * dims[1] * dims[2];
+    /* Put back the fill value. */
+    if (real_missing_mode == 1) {
+      assert(mask);
+      icecream cream;
+      icecream_use_mem(&cream, mask, mask_bytes);
+      if (is_float) {
+        float* p = (float*)dst;
+        for (size_t i = 0; i < nelem; i++) {
+          if (icecream_rbit(&cream))
+            p[i] = nanf("1");
+        }
+      }
+      else {
+        double* p = (double*)dst;
+        for (size_t i = 0; i < nelem; i++) {
+          if (icecream_rbit(&cream))
+            p[i] = nan("1");
+        }
+      }
+      free(mask);
+      mask = NULL;
+    }
+    else if (real_missing_mode == 2) {
+      assert(mask);
+      icecream cream;
+      icecream_use_mem(&cream, mask, mask_bytes);
+      if (is_float) {
+        float* p = (float*)dst;
+        for (size_t i = 0; i < nelem; i++) {
+          if (icecream_rbit(&cream))
+            p[i] = fill_val_f;
+        }
+      }
+      else {
+        double* p = (double*)dst;
+        for (size_t i = 0; i < nelem; i++) {
+          if (icecream_rbit(&cream))
+            p[i] = fill_val_d;
+        }
+      }
+      free(mask);
+      mask = NULL;
+    }
+
     if (dst_len <= *buf_size) { /* Re-use the input buffer */
       memcpy(*buf, dst, dst_len);
-      free(dst); /* allocated by SPERR, using malloc() */
+      free(dst); /* allocated by SPERR using malloc() */
       dst = NULL;
     }
     else {                 /* Point to the new buffer */
@@ -285,47 +420,143 @@ static size_t H5Z_filter_sperr(unsigned int flags,
 
     return dst_len;
 
-  }      /* Finish Decompression */
+  } /* Finish Decompression */
   else { /* Compression */
 
-    /* Sanity check on the data size. */
-    if ((is_float ? 4ul : 8ul) * dims[0] * dims[1] * dims[2] != nbytes) {
+    /* Sanity check on the data size */
+    const size_t nelem = (size_t)dims[0] * dims[1] * dims[2];
+    if ((is_float ? 4ul : 8ul) * nelem != nbytes) {
       H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADSIZE,
               "Compression: input buffer len isn't right.");
       return 0;
     }
 
-    void* dst = NULL; /* buffer to hold the compressed bitstream */
-    size_t dst_len = 0;
+    /* Step 1: figure out if there really exists missing values as specified. */
+    int real_missing_mode = 0;
+    if (missing_val_mode == 1 && h5zsperr_has_nan(*buf, nelem, is_float))
+      real_missing_mode = 1;
+    else if (missing_val_mode == 2 && h5zsperr_has_large_mag(*buf, nelem, is_float))
+      real_missing_mode = 2;
+
+    /* Step 2: save a compact bitmask indicating the missing value locations. */
+    size_t mask_useful_bytes = 0;
+    void* mask = NULL;
+    if (real_missing_mode != 0) {
+      size_t mask_bytes = nelem / 4; /* just pick a big enough value */
+      mask = malloc(mask_bytes);
+      int ret = 0;
+      if (real_missing_mode == 1) {
+        ret = h5zsperr_make_mask_nan(*buf, nelem, is_float, mask, mask_bytes, &mask_useful_bytes);
+      }
+      else if (real_missing_mode == 2) {
+        ret = h5zsperr_make_mask_large_mag(*buf, nelem, is_float, 
+                                           mask, mask_bytes, &mask_useful_bytes);
+      }
+
+      if (ret) {
+        free(mask);
+        H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADVALUE,
+                "SPERR compacting bitmask failed.");
+        return 0;
+      }
+    }
+
+    /* Step 3: treat the input buffer with missing values replaced. */
+    float replace_f = 0.f;
+    double replace_d = 0.0;
+    if (real_missing_mode == 1) {
+      /* not really making use of the return value */
+      if (is_float)
+        replace_f = h5zsperr_treat_nan_f32(*buf, nelem);
+      else
+        replace_d = h5zsperr_treat_nan_f64(*buf, nelem);
+    }
+    else if (real_missing_mode == 2) {
+      /* Keep the large-magnitude value to be replaced. */
+      if (is_float)
+        replace_f = h5zsperr_treat_large_mag_f32(*buf, nelem);
+      else
+        replace_d = h5zsperr_treat_large_mag_f64(*buf, nelem);
+    }
+
+    /* Step 4: SPERR compression! */
+    void* sperr = NULL; /* buffer to hold the compressed bitstream */
+    size_t sperr_len = 0;
     int ret = 0;
 
-    if (rank == 2)
-      ret = sperr_comp_2d(*buf, is_float, dims[0], dims[1], mode, quality, 0, &dst, &dst_len);
-    else
+    if (rank == 2) {
+      ret = sperr_comp_2d(*buf, is_float, dims[0], dims[1], comp_mode, quality, 0,
+                          &sperr, &sperr_len);
+    }
+    else {
       ret = sperr_comp_3d(*buf, is_float, dims[0], dims[1], dims[2], dims[0], dims[1], dims[2],
-                          mode, quality, 1, &dst, &dst_len);
-    if (ret != 0) {
-      if (dst) {
-        free(dst); /* allocated by SPERR, using malloc() */
-        dst = NULL;
+                          comp_mode, quality, 1, &sperr, &sperr_len);
+    }
+    if (ret) {
+      if (sperr) {
+        free(sperr); /* allocated by SPERR using malloc() */
+        sperr = NULL;
+      }
+      if (mask) {
+        free(mask);
+        mask = NULL;
       }
       H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADVALUE,
               "SPERR compression failed.");
       return 0;
     }
 
-    if (dst_len <= *buf_size) { /* Re-use the input buffer */
-      memcpy(*buf, dst, dst_len);
-      free(dst); /* allocated by SPERR, using malloc() */
-      dst = NULL;
-    }
-    else {                 /* Point to the new buffer */
-      H5free_memory(*buf); /* allocated by HDF5 */
-      *buf = dst;
-      *buf_size = dst_len;
+    /* Step 5: assemble the final output.
+     *
+     * The assembled output has the following format:
+     * -- 1 byte: the missing value mode.
+     * -- 4 or 8 bytes: the large-mag value being replaced, in missing value mode 2.
+     *    0 byte: in missing value mode 0 or 1.
+     * -- A compact bitmask, in missing value mode 1 or 2.
+     *    0 byte: in missing value mode 0.
+     * -- The regular SPERR bitstream.
+     */
+    size_t out_len = sperr_len + 1;
+    if (real_missing_mode == 2)
+      out_len += is_float ? 4 : 8;
+    if (real_missing_mode != 0)
+      out_len += mask_useful_bytes;
+
+    if (out_len > *buf_size) { /* Need to allocate a new buffer */
+      H5free_memory(*buf);
+      *buf = H5allocate_memory(out_len, false);
+      *buf_size = out_len;
     }
 
-    return dst_len;
+    /* copy the missing value mode */
+    uint8_t* p = (uint8_t*)(*buf);
+    p[0] = (uint8_t)real_missing_mode;
+    size_t offset = 1;
+
+    /* copy the missing value to be filled */
+    if (real_missing_mode == 2) {
+      if (is_float)
+        memcpy(p + offset, &replace_f, sizeof(replace_f));
+      else
+        memcpy(p + offset, &replace_d, sizeof(replace_d));
+      offset += is_float ? 4 : 8;
+    }
+
+    /* copy the missing value mask */
+    if (real_missing_mode != 0) {
+      assert(mask);
+      memcpy(p + offset, mask, mask_useful_bytes);
+      offset += mask_useful_bytes;
+      free(mask);
+      mask = NULL;
+    }
+
+    /* copy the SPERR bitstream */
+    memcpy(p + offset, sperr, sperr_len);
+    free(sperr);
+    sperr = NULL;
+
+    return out_len;
 
   } /* Finish compression */
 }

--- a/src/H5Z-SPERR/src/h5zsperr_helper.cpp
+++ b/src/H5Z-SPERR/src/h5zsperr_helper.cpp
@@ -1,0 +1,251 @@
+#include <algorithm>
+#include <cassert>
+#include <cmath>  // isnan()
+#include <memory>
+
+#include <H5PLextern.h>
+#include <hdf5.h>
+#include "h5zsperr_helper.h"
+
+#include "compactor.h"
+#include "icecream.h"
+
+unsigned int C_API::h5zsperr_pack_extra_info(int rank, int is_float, int missing_val_mode, int magic)
+{
+  assert(rank == 3 || rank == 2);
+  assert(is_float == 1 || is_float == 0);
+  assert(missing_val_mode >= 0 && missing_val_mode <= 2);
+  assert(magic >= 0 && magic <= 63);
+
+  unsigned int ret = 0;
+
+  // Bit positions 0-3 to encode the rank.
+  if (rank == 2)
+    ret |= 1u << 1; // Position 1
+  else {
+    ret |= 1u;      // Position 0
+    ret |= 1u << 1; // Position 1
+  }
+
+  // Bit positions 4-5 encode data type.
+  if (is_float == 1)
+    ret |= 1u << 4; // Position 4
+
+  // Bit positions 6-9 encode missing value mode.
+  ret |= missing_val_mode << 6;
+
+  // Bit positions 10-15 encode the magic number.
+  ret |= magic << 10;
+
+  return ret;
+}
+
+void C_API::h5zsperr_unpack_extra_info(unsigned int meta,
+                                       int* rank,
+                                       int* is_float,
+                                       int* missing_val_mode,
+                                       int* magic)
+{
+  // Extract rank from bit positions 0-3.
+  unsigned pos0 = meta & 1u;
+  unsigned pos1 = meta & (1u << 1);
+  if (!pos0 && pos1)
+    *rank = 2;
+  else if (pos0 && pos1)
+    *rank = 3;
+  else { // error
+    H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADVALUE,
+            "Rank is not 2 or 3.");
+  }
+
+  // Extract data type from positions 4-5.
+  unsigned pos4 = meta & (1u << 4);
+  if (pos4)
+    *is_float = 1;
+  else
+    *is_float = 0; // is_double
+
+  // Extract missing value mode from positions 6-9.
+  *missing_val_mode = 15; // 2^4 = 16
+  *missing_val_mode &= meta >> 6;
+
+  // Extract the magic number from positions 10-15.
+  *magic = 63;  // 2^6 = 64
+  *magic &= meta >> 10;
+}
+
+int C_API::h5zsperr_has_nan(const void* buf, size_t nelem, int is_float)
+{
+  assert(is_float == 1 || is_float == 0);
+  if (is_float) {
+    const float* p = (const float*)buf;
+    return std::any_of(p, p + nelem, [](auto v) { return std::isnan(v); });
+  }
+  else {
+    const double* p = (const double*)buf;
+    return std::any_of(p, p + nelem, [](auto v) { return std::isnan(v); });
+  }
+}
+
+int C_API::h5zsperr_has_large_mag(const void* buf, size_t nelem, int is_float)
+{
+  assert(is_float == 1 || is_float == 0);
+  if (is_float) {
+    const float* p = (const float*)buf;
+    return std::any_of(p, p + nelem, [](auto v) { return std::abs(v) >= LARGE_MAGNITUDE_F; });
+  }
+  else {
+    const double* p = (const double*)buf;
+    return std::any_of(p, p + nelem, [](auto v) { return std::abs(v) >= LARGE_MAGNITUDE_D; });
+  }
+}
+
+int C_API::h5zsperr_make_mask_nan(const void* data_buf, size_t nelem, int is_float,
+                                  void* mask_buf, size_t mask_bytes, size_t* useful_bytes)
+{
+  assert(is_float == 0 || is_float == 1);
+
+  // First, make a naive mask.
+  //
+  auto nbytes = (nelem + 7) / 8;
+  while (nbytes % 8)
+    nbytes++;
+  auto mem = std::make_unique<uint8_t[]>(nbytes);
+  auto s1 = icecream();
+  icecream_use_mem(&s1, mem.get(), nbytes);
+
+  if (is_float) {
+    const float* p = (const float*)data_buf;
+    for (size_t i = 0; i < nelem; i++)
+      icecream_wbit(&s1, std::isnan(p[i]));
+  }
+  else {
+    const double* p = (const double*)data_buf;
+    for (size_t i = 0; i < nelem; i++)
+      icecream_wbit(&s1, std::isnan(p[i]));
+  }
+  icecream_flush(&s1);
+
+  // Second, compact this naive mask.
+  //
+  while (mask_bytes % 8)
+    mask_bytes--;
+  if (mask_bytes < compactor_comp_size(mem.get(), nbytes))
+    return 1; // Not enough space!
+
+  *useful_bytes = compactor_encode(mem.get(), nbytes, mask_buf, mask_bytes);
+
+  return 0;
+}
+
+int C_API::h5zsperr_make_mask_large_mag(const void* data_buf, size_t nelem, int is_float,
+                                        void* mask_buf, size_t mask_bytes, size_t* useful_bytes)
+{
+  assert(is_float == 0 || is_float == 1);
+
+  // First, make a naive mask.
+  //
+  auto nbytes = (nelem + 7) / 8;
+  while (nbytes % 8)
+    nbytes++;
+  auto mem = std::make_unique<uint8_t[]>(nbytes);
+  auto s1 = icecream();
+  icecream_use_mem(&s1, mem.get(), nbytes);
+
+  if (is_float) {
+    const float* p = (const float*)data_buf;
+    for (size_t i = 0; i < nelem; i++)
+      icecream_wbit(&s1, std::abs(p[i]) >= LARGE_MAGNITUDE_F);
+  }
+  else {
+    const double* p = (const double*)data_buf;
+    for (size_t i = 0; i < nelem; i++)
+      icecream_wbit(&s1, std::abs(p[i]) >= LARGE_MAGNITUDE_D);
+  }
+  icecream_flush(&s1);
+
+  // Second, compact this naive mask.
+  //
+  while (mask_bytes % 8)
+    mask_bytes--;
+  if (mask_bytes < compactor_comp_size(mem.get(), nbytes))
+    return 1; // Not enough space!
+
+  *useful_bytes = compactor_encode(mem.get(), nbytes, mask_buf, mask_bytes);
+
+  return 0;
+}
+
+template<typename T>
+T treat_nan_impl(T* buf, size_t nelem)
+{
+  // First, find the mean value.
+  const size_t BLOCK = 2048;
+  double total_sum = 0.0, block_sum = 0.0;
+  size_t total_cnt = 0, block_cnt = 0;
+
+  for (size_t i = 0; i < nelem; i++) {
+    if (!std::isnan(buf[i])) {
+      block_sum += double(buf[i]);
+      if (++block_cnt == BLOCK) {
+        total_sum += block_sum;
+        total_cnt += BLOCK;
+        block_sum = 0.0;
+        block_cnt = 0;
+      }
+    }
+  }
+  double mean = (total_sum + block_sum) / double(total_cnt + block_cnt);
+
+  // Second, replace every occurance of NaN
+  std::replace_if(buf, buf + nelem, [](auto v) { return std::isnan(v); }, T(mean));
+
+  return T(mean);
+}
+float C_API::h5zsperr_treat_nan_f32(float* data_buf, size_t nelem)
+{
+  return treat_nan_impl(data_buf, nelem);
+}
+double C_API::h5zsperr_treat_nan_f64(double* data_buf, size_t nelem)
+{
+  return treat_nan_impl(data_buf, nelem);
+}
+
+template<typename T>
+T treat_large_mag_impl(T* buf, size_t nelem)
+{
+  // First, find the mean value.
+  constexpr T MAG = sizeof(T) == 4 ? LARGE_MAGNITUDE_F : LARGE_MAGNITUDE_D;
+  const size_t BLOCK = 2048;
+  double total_sum = 0.0, block_sum = 0.0;
+  size_t total_cnt = 0, block_cnt = 0;
+
+  for (size_t i = 0; i < nelem; i++) {
+    if (std::abs(buf[i]) < MAG) {
+      block_sum += double(buf[i]);
+      if (++block_cnt == BLOCK) {
+        total_sum += block_sum;
+        total_cnt += BLOCK;
+        block_sum = 0.0;
+        block_cnt = 0;
+      }
+    }
+  }
+  double mean = (total_sum + block_sum) / double(total_cnt + block_cnt);
+
+  // Second, find the first large magnitude value.
+  auto orig = *(std::find_if(buf, buf + nelem, [MAG](auto v) { return std::abs(v) >= MAG; }));
+
+  // Third, replace every occurance of large magnitude
+  std::replace_if(buf, buf + nelem, [MAG](auto v) { return std::abs(v) >= MAG; }, T(mean));
+
+  return orig;
+}
+float C_API::h5zsperr_treat_large_mag_f32(float* data_buf, size_t nelem)
+{
+  return treat_large_mag_impl(data_buf, nelem);
+}
+double C_API::h5zsperr_treat_large_mag_f64(double* data_buf, size_t nelem)
+{
+  return treat_large_mag_impl(data_buf, nelem);
+}

--- a/src/H5Z-SPERR/src/icecream.c
+++ b/src/H5Z-SPERR/src/icecream.c
@@ -1,0 +1,58 @@
+#include "icecream.h"
+
+void icecream_use_mem(icecream* s, void* mem, size_t bytes) {
+  s->begin = (uint64_t*)mem;
+  icecream_rewind(s);
+}
+
+void icecream_rewind(icecream* s)
+{
+  s->ptr = s->begin;
+  s->buffer = 0;
+  s->bits = 0;
+}
+
+int icecream_rbit(icecream* s)
+{
+  if (!s->bits) {
+    s->buffer = *(s->ptr);
+    (s->ptr)++;
+    s->bits = 64;
+  }
+  (s->bits)--;
+  int bit = s->buffer & (uint64_t)1;
+  s->buffer >>= 1;
+  return bit;
+}
+
+void icecream_wbit(icecream* s, int bit)
+{
+  s->buffer |= (uint64_t)bit << s->bits;
+    
+  if (++(s->bits) == 64) {
+    *(s->ptr) = s->buffer;
+    (s->ptr)++;
+    s->bits = 0;
+    s->buffer = 0;
+  }
+}
+
+size_t icecream_wtell(icecream* s)
+{
+  return (s->ptr - s->begin) * (size_t)64 + s->bits;
+}
+
+size_t icecream_rtell(icecream* s)
+{
+  return (s->ptr - s->begin) * (size_t)64 - s->bits;
+}
+
+void icecream_flush(icecream* s)
+{
+  if (s->bits) {  /* only really flush when there are remaining bits */
+    *(s->ptr) = s->buffer;
+    (s->ptr)++; 
+    s->buffer = 0;
+    s->bits = 0;
+  }
+}

--- a/src/H5Z-SPERR/test_scripts/CMakeLists.txt
+++ b/src/H5Z-SPERR/test_scripts/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_executable(        compactor_test compactor_test.cpp )
+target_link_libraries( compactor_test PUBLIC h5z-sperr GTest::gtest_main )
+
+add_executable(        icecream_test icecream_test.cpp )
+target_link_libraries( icecream_test PUBLIC h5z-sperr GTest::gtest_main )
+
+add_executable(        helper_test h5zsperr_helper_test.cpp )
+target_link_libraries( helper_test PUBLIC h5z-sperr GTest::gtest_main )
+
+include(GoogleTest)
+gtest_discover_tests( compactor_test )
+gtest_discover_tests( icecream_test )
+gtest_discover_tests( helper_test )

--- a/src/H5Z-SPERR/test_scripts/compactor_test.cpp
+++ b/src/H5Z-SPERR/test_scripts/compactor_test.cpp
@@ -1,0 +1,118 @@
+#include "gtest/gtest.h"
+#include <vector>
+#include <limits>
+#include <memory>
+
+#include "compactor.h"
+
+namespace {
+
+TEST(compactor, strategy) {
+  //
+  // This test assumes that the compactor uses 32-bit integers.
+  //
+  // Create an array of all zeros
+  size_t N = 32;
+  auto buf = std::vector<unsigned int>(N, 0); 
+  auto ans = compactor_strategy(buf.data(), N * sizeof(unsigned int)); 
+  EXPECT_EQ(ans, 0);
+
+  // Make the array of all ones 
+  buf.assign(N, std::numeric_limits<unsigned int>::max());
+  ans = compactor_strategy(buf.data(), N * sizeof(unsigned int)); 
+  EXPECT_EQ(ans, 1);
+
+  // Make the array half half
+  for (int i = 0; i < N / 2; i++)
+    buf[i] = 0;
+  ans = compactor_strategy(buf.data(), N * sizeof(unsigned int)); 
+  EXPECT_EQ(ans, 0);
+}
+
+TEST(compactor, comp_size) {
+  //
+  // This test assumes that the compactor uses 32-bit integers.
+  //
+  // Create an array of all zeros
+  size_t N = 32;
+  auto buf = std::vector<unsigned int>(N, 0);
+  auto ans = compactor_comp_size(buf.data(), N * sizeof(unsigned int));
+  EXPECT_EQ(ans, 9);
+
+  // Make the array of all ones
+  buf.assign(N, std::numeric_limits<unsigned int>::max());
+  ans = compactor_comp_size(buf.data(), N * sizeof(unsigned int));
+  EXPECT_EQ(ans, 9);
+
+  // Make the array half half
+  for (int i = 0; i < N / 2; i++)
+    buf[i] = 0;
+  ans = compactor_comp_size(buf.data(), N * sizeof(unsigned int));
+  EXPECT_EQ(ans, 11);
+
+  // Make the array 24 0's, 8 1's.
+  for (int i = 0; i < N / 4; i++)
+    buf[i] = buf[N - 1];
+  ans = compactor_comp_size(buf.data(), N * sizeof(unsigned int));
+  EXPECT_EQ(ans, 10);
+
+  // Append the array with ints that need to be verbosely encoded.
+  buf.push_back(1);
+  buf.push_back(2);
+  ans = compactor_comp_size(buf.data(), buf.size() * sizeof(unsigned int));
+  EXPECT_EQ(ans, 18);
+}
+
+TEST(compactor, coding_all0_all1)
+{
+  // an array of all 0's
+  int nbytes = 128;  // 32 ints
+  auto buf = std::vector<unsigned char>(nbytes, 0);
+
+  // encode `buf`
+  auto encode = std::make_unique<unsigned char[]>(nbytes);
+  auto encode_len = compactor_encode(buf.data(), nbytes, encode.get(), nbytes);
+  EXPECT_EQ(encode_len, compactor_comp_size(buf.data(), nbytes));
+
+  // decode and test all 0's
+  auto decode = std::make_unique<unsigned char[]>(nbytes);
+  auto decode_len = compactor_decode(encode.get(), nbytes, decode.get());
+  EXPECT_EQ(decode_len, nbytes);
+  for (int i = 0; i < nbytes; i++)
+    ASSERT_EQ(decode[i], 0) << "i = " << i;
+
+  // assign the entire array to be all 1's, and test again
+  buf.assign(nbytes, 255);
+  encode_len = compactor_encode(buf.data(), nbytes, encode.get(), nbytes);
+  EXPECT_EQ(encode_len, compactor_comp_size(buf.data(), nbytes));
+  decode_len = compactor_decode(encode.get(), nbytes, decode.get());
+  EXPECT_EQ(decode_len, nbytes);
+  for (int i = 0; i < nbytes; i++)
+    ASSERT_EQ(decode[i], 255) << "i = " << i;
+}
+
+TEST(compactor, coding_mixed)
+{
+  int nbytes = 64;  // 16 ints
+  auto buf = std::vector<unsigned char>(nbytes, 0);
+  for (int i = 0; i < nbytes / 4; i++)
+    buf[i] = 255;
+  for (int i = nbytes / 4; i < nbytes / 2; i++)
+    buf[i] = i;
+  buf[nbytes - 1] = 255;
+
+  // encode `buf`
+  auto encode = std::make_unique<unsigned char[]>(nbytes);
+  auto encode_len = compactor_encode(buf.data(), nbytes, encode.get(), nbytes);
+  EXPECT_EQ(encode_len, compactor_comp_size(buf.data(), nbytes));
+
+  // decode and compare to the original
+  auto decode = std::make_unique<unsigned char[]>(nbytes);
+  auto decode_len = compactor_decode(encode.get(), nbytes, decode.get());
+  EXPECT_EQ(decode_len, nbytes);
+  for (int i = 0; i < nbytes; i++)
+    ASSERT_EQ(buf[i], decode[i]) << "i = " << i;
+}
+
+} // End of the namespace
+

--- a/src/H5Z-SPERR/test_scripts/h5zsperr_helper_test.cpp
+++ b/src/H5Z-SPERR/test_scripts/h5zsperr_helper_test.cpp
@@ -1,0 +1,156 @@
+#include "gtest/gtest.h"
+
+#include <cmath>
+#include <numeric>
+#include <memory>
+
+#include "h5zsperr_helper.h"
+#include "compactor.h"
+#include "icecream.h"
+
+namespace {
+
+TEST(h5zsperr_helper, pack_extra_info)
+{
+  // Test all possible combinations
+  int rank = 0, is_float = 0, missing_val_mode = 0, magic = 0;
+  for (int r = 2; r <= 3; r++)
+    for (int f = 0; f <= 1; f++)
+      for (int m = 0; m <= 2; m++)
+        for (int g = 0; g <= 63; g++) {
+          auto encode = C_API::h5zsperr_pack_extra_info(r, f, m, g);
+          rank = r * f * m + 10;
+          is_float = rank + 10;
+          missing_val_mode = rank + 20;
+          magic = rank - 20;
+          C_API::h5zsperr_unpack_extra_info(encode, &rank, &is_float, &missing_val_mode, &magic);
+          ASSERT_EQ(rank, r);
+          ASSERT_EQ(is_float, f);
+          ASSERT_EQ(missing_val_mode, m);
+          ASSERT_EQ(magic, g);
+      }
+}
+
+TEST(h5zsperr_helper, make_mask_nan1)
+{
+  // Create a float array with just a few NaNs.
+  int N = 256;
+  auto buf = std::vector<float>(N);
+  for (int i = 0; i < N; i++)
+    buf[i] = float(i);
+  buf[50] = std::nanf("1");
+  buf[90] = std::nanf("1");
+  buf[200] = std::nanf("1");
+
+  // Create a mask using std::vector<bool>.
+  auto mask1 = std::vector<bool>(N);
+  for (int i = 0; i < N; i++)
+    mask1[i] = std::isnan(buf[i]);
+
+  // Create a compact mask using the helper function.
+  size_t nbytes = N / 8;
+  auto mask2 = std::make_unique<char[]>(nbytes);
+  size_t useful_bytes2 = 0;
+  auto ret = C_API::h5zsperr_make_mask_nan(buf.data(), N, 1, mask2.get(), nbytes, &useful_bytes2);
+  ASSERT_EQ(ret, 0);
+
+  // Decode mask2
+  auto mask3 = std::make_unique<char[]>(N);
+  auto useful_bytes3 = compactor_decode(mask2.get(), nbytes, mask3.get());
+  ASSERT_EQ(useful_bytes3, nbytes);
+
+  // Test that mask3 equals mask1
+  auto s1 = icecream();
+  icecream_use_mem(&s1, mask3.get(), N);
+  for (int i = 0; i < N; i++)
+    ASSERT_EQ(mask1[i], icecream_rbit(&s1));
+}
+
+TEST(h5zsperr_helper, make_mask_nan2)
+{
+  // Create a float array with just a few non-NaNs.
+  int N = 300;
+  auto buf = std::vector<float>(N);
+  for (int i = 0; i < N; i++)
+    buf[i] = std::nanf("1");
+  buf[50] = 50.f;
+  buf[90] = 90.f;
+  buf[200] = 200.f;
+  buf[299] = 299.f;
+
+  // Create a mask using std::vector<bool>.
+  auto mask1 = std::vector<bool>(N);
+  for (int i = 0; i < N; i++)
+    mask1[i] = std::isnan(buf[i]);
+
+  // Create a compact mask using the helper function.
+  size_t nbytes = (N + 7) / 8;
+  auto mask2 = std::make_unique<char[]>(nbytes);
+  size_t useful_bytes2 = 0;
+  auto ret = C_API::h5zsperr_make_mask_nan(buf.data(), N, 1, mask2.get(), nbytes, &useful_bytes2);
+  ASSERT_EQ(ret, 0);
+
+  // Decode mask2
+  auto mask3 = std::make_unique<char[]>(N);
+  while (useful_bytes2 % 8)
+    useful_bytes2++;
+  auto decoded_bytes3 = compactor_decode(mask2.get(), useful_bytes2, mask3.get());
+
+  // Test that mask3 equals mask1
+  auto s1 = icecream();
+  icecream_use_mem(&s1, mask3.get(), N);
+  for (int i = 0; i < N; i++)
+    ASSERT_EQ(mask1[i], icecream_rbit(&s1));
+}
+
+TEST(h5zsperr_helper, treat_nan)
+{
+  size_t N = 131;
+  auto buf = std::vector<float>(N);
+  for (size_t i = 0; i < N; i++)
+    buf[i] = float(i + 1) * 0.5f;
+  buf[10] = 0.f;
+  buf[20] = 0.f;
+  buf[90] = 0.f;
+  auto mean = std::accumulate(buf.begin(), buf.end(), 0.f) / 128.f;
+  buf[10] = mean;
+  buf[20] = mean;
+  buf[90] = mean;
+
+  auto buf2 = buf;
+  buf2[10] = std::nanf("1");
+  buf2[20] = std::nanf("1");
+  buf2[90] = std::nanf("1");
+  auto mean2 = C_API::h5zsperr_treat_nan_f32(buf2.data(), N);
+
+  ASSERT_FLOAT_EQ(mean, mean2);
+  for (size_t i = 0; i < N; i++)
+    ASSERT_FLOAT_EQ(buf[i], buf2[i]) << "i = " << i;
+}
+
+TEST(h5zsperr_helper, treat_large_mag)
+{
+  size_t N = 120;
+  auto buf = std::vector<double>(N);
+  for (size_t i = 0; i < N; i++)
+    buf[i] = double(i + 1) * 0.5;
+  buf[10] = 0.0;
+  buf[20] = 0.0;
+  buf[90] = 0.0;
+  auto mean = std::accumulate(buf.begin(), buf.end(), 0.0) / 117.f;
+  buf[10] = mean;
+  buf[20] = mean;
+  buf[90] = mean;
+
+  auto buf2 = buf;
+  buf2[10] = LARGE_MAGNITUDE_D;
+  buf2[20] = LARGE_MAGNITUDE_D;
+  buf2[90] = LARGE_MAGNITUDE_D;
+  auto tmp = C_API::h5zsperr_treat_large_mag_f64(buf2.data(), N);
+  ASSERT_EQ(tmp, LARGE_MAGNITUDE_D);
+
+  for (size_t i = 0; i < N; i++)
+    ASSERT_DOUBLE_EQ(buf[i], buf2[i]) << "i = " << i;
+}
+
+}

--- a/src/H5Z-SPERR/test_scripts/icecream_test.cpp
+++ b/src/H5Z-SPERR/test_scripts/icecream_test.cpp
@@ -1,0 +1,71 @@
+#include "gtest/gtest.h"
+#include <vector>
+#include <memory>
+#include <random>
+#include <cstring> // std::memcpy()
+
+#include "icecream.h"
+
+namespace {
+
+TEST(icecream, StreamWriteRead)
+{
+  const size_t N = 159;
+  auto mem = std::make_unique<uint64_t[]>(4);
+  auto s1 = icecream();
+  icecream_use_mem(&s1, mem.get(), 4);
+  auto vec = std::vector<bool>(N);
+
+  // Make N writes
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<unsigned int> distrib1(0, 1);
+  for (size_t i = 0; i < N; i++) {
+    const auto bit = distrib1(gen);
+    vec[i] = bit;
+    EXPECT_EQ(icecream_wtell(&s1), i) << " at idx = " << i;
+    icecream_wbit(&s1, bit);
+    EXPECT_EQ(icecream_wtell(&s1), i + 1) << " at idx = " << i;
+  }
+  EXPECT_EQ(icecream_wtell(&s1), N);
+  icecream_flush(&s1);
+  EXPECT_EQ(icecream_wtell(&s1), 192);
+
+  icecream_rewind(&s1);
+  for (size_t i = 0; i < N; i++) {
+    EXPECT_EQ(icecream_rtell(&s1), i) << " at idx = " << i;
+    EXPECT_EQ(icecream_rbit(&s1), vec[i]) << " at idx = " << i;
+    EXPECT_EQ(icecream_rtell(&s1), i + 1) << " at idx = " << i;
+  }
+}
+
+TEST(icecream, PartialWord)
+{
+  auto mem = std::make_unique<char[]>(20);
+  auto s1 = icecream();
+  icecream_use_mem(&s1, mem.get(), 20);
+  auto vec = std::vector<bool>();
+
+  // Make 80 writes. The first 10 bytes are supposed to keep the result.
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<unsigned int> distrib(0, 1);
+  for (int i = 0; i < 80; i++) {
+    const auto bit = distrib(gen);
+    vec.push_back(bit);
+    icecream_wbit(&s1, bit);
+  }
+  icecream_flush(&s1);
+
+  // Copy over the first 10 bytes, and test if the bits are the same.
+  auto mem2 = std::make_unique<char[]>(16);
+  for (int i = 0; i < 16; i++)
+    mem2[i] = 15;
+  std::memcpy(mem2.get(), mem.get(), 10);
+  icecream_use_mem(&s1, mem2.get(), 16);
+  for (int i = 0; i < 80; i++)
+    EXPECT_EQ(icecream_rbit(&s1), vec[i]) << " at idx = " << i;
+}
+
+
+}

--- a/src/hdf5plugin/_filters.py
+++ b/src/hdf5plugin/_filters.py
@@ -487,6 +487,8 @@ class Sperr(h5py.filters.FilterRefBase):
 
     If the ``swap`` argument is True (False by default) a "rank order swap" pre-filtering is performed.
 
+    The ``missing_value_mode`` argument indicates which value is used to indicate missing data.
+
     For more details, see `H5Z-SPERR <https://github.com/NCAR/H5Z-SPERR>`_.
     """
     filter_name = "sperr"
@@ -495,14 +497,30 @@ class Sperr(h5py.filters.FilterRefBase):
     _FRACTIONAL_BITS = 16
     _INTEGER_BITS = 12
 
+    NO_MISSING = 0
+    """No missing value."""
+
+    MISSING_NAN = 1
+    """Any NAN is a missing value."""
+
+    MISSING_1E35 = 2
+    """Any value where abs(value) >= 1e35 is a missing value.
+
+    The first occurance of a value with a magnitude larger than 1e35 will be used to fill in all missing value locations.
+    """
+
     def __init__(
             self,
             rate: float | None = None,
             peak_signal_to_noise_ratio: float | None = None,
             absolute: float | None = None,
-            swap: bool = False):
+            swap: bool = False,
+            missing_value_mode: int = NO_MISSING,
+        ):
         if (rate, peak_signal_to_noise_ratio, absolute).count(None) < 2:
             raise TypeError("hdf5plugin.Sperr() takes at most one not None argument")
+        if missing_value_mode not in (self.NO_MISSING, self.MISSING_NAN, self.MISSING_1E35):
+            raise ValueError(f"Unsupported missing_value_mode: {missing_value_mode}")
 
         if peak_signal_to_noise_ratio is not None:
             assert peak_signal_to_noise_ratio > 0
@@ -517,10 +535,10 @@ class Sperr(h5py.filters.FilterRefBase):
             mode = 1
             quality = 16 if rate is None else rate
 
-        self.filter_options = self.__pack_options(mode, quality, swap)
+        self.filter_options = self.__pack_options(mode, quality, swap, missing_value_mode)
 
     @classmethod
-    def __pack_options(cls, mode: int, quality: float, swap: bool) -> tuple[int]:
+    def __pack_options(cls, mode: int, quality: float, swap: bool, missing_value_mode: int) -> tuple[int]:
         assert mode in (1, 2, 3)
         assert quality > 0
 
@@ -548,7 +566,7 @@ class Sperr(h5py.filters.FilterRefBase):
         if swap:
             ret |= 1 << (cls._INTEGER_BITS + cls._FRACTIONAL_BITS + 3)
 
-        return (ret,)
+        return ret, missing_value_mode
 
 
 class SZ(h5py.filters.FilterRefBase):

--- a/src/hdf5plugin/test.py
+++ b/src/hdf5plugin/test.py
@@ -269,6 +269,8 @@ class TestHDF5PluginRW(BaseTestHDF5PluginRW):
         tests = [
             {'lossless': False, 'rate': 16},
             {'lossless': False, 'rate': 16, 'swap': True},
+            {'lossless': False, 'rate': 16, 'swap': True, 'missing_value_mode': hdf5plugin.Sperr.MISSING_NAN},
+            {'lossless': False, 'rate': 16, 'swap': True, 'missing_value_mode': hdf5plugin.Sperr.MISSING_1E35},
             {'lossless': False, 'peak_signal_to_noise_ratio': 1e-4},
             {'lossless': False, 'peak_signal_to_noise_ratio': 1e-4, 'swap': True},
             {'lossless': False, 'absolute': 1e-4},


### PR DESCRIPTION
This MR updates h5z-sperr to version ~~[0.2.1](https://github.com/NCAR/H5Z-SPERR/releases/tag/v0.2.1)~~ [0.2.3](https://github.com/NCAR/H5Z-SPERR/releases/tag/v0.2.3).
A new `cd_values` is added to pass ["missing_value_mode"](https://github.com/NCAR/H5Z-SPERR/tree/v0.2.1?tab=readme-ov-file#handling-of-missing-values)