### PR TITLE
Code quality: Fixed bandit warning, update code pyupgrade --py38-plus; CI: Added bandit check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
-      - run: python -m pip install --upgrade pip build twine
+      - run: python -m pip install --upgrade pip bandit build twine
+      - run: bandit -c pyproject.toml -r .
       - run: python -m build --sdist
       - run: python -m twine check dist/*
       # Build documentation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,8 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
-      - run: python -m pip install --upgrade pip build twine
+      - run: python -m pip install --upgrade pip bandit build twine
+      - run: bandit -c pyproject.toml -r .
       - run: python -m build --sdist
       - run: python -m twine check dist/*
       - run: pip install --pre "$(ls dist/hdf5plugin*.tar.gz)[test]"

--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -24,6 +24,13 @@ To also run tests relying on actual HDF5 files, run from the source directory::
 
 This tests the installed version of `hdf5plugin`.
 
+Linting
+=======
+
+Run `bandit <https://github.com/PyCQA/bandit/>_` security linter from the source directory::
+
+   bandit -c pyproject.toml -r .
+
 Building documentation
 ======================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,32 @@ package-dir = {"" = "src"}
 
 [tool.setuptools.dynamic]
 version = {attr = "hdf5plugin._version.version"}
+
+[tool.bandit]
+exclude_dirs = [
+    "build",
+    "doc/hdf5plugin_EuropeanHUG2023",
+    "src/bitshuffle",
+    "src/bzip2",
+    "src/c-blosc",
+    "src/c-blosc2",
+    "src/charls",
+    "src/fcidecomp",
+    "src/H5Z-SPERR",
+    "src/H5Z-ZFP",
+    "src/hdf5-blosc",
+    "src/HDF5PLUGIN_Zstandard",
+    "src/LZ4",
+    "src/lz4_ipp",
+    "src/PyTables",
+    "src/snappy",
+    "src/SPERR",
+    "src/SZ",
+    "src/SZ3",
+    "src/SZ3_extra",
+    "src/SZ_extra",
+    "src/zfp",
+]
+
+[tool.bandit.assert_used]
+skips = ["*test.py"]

--- a/setup.py
+++ b/setup.py
@@ -349,7 +349,8 @@ class BuildConfig:
         It first checks if the corresponding HDF5PLUGIN_* environment variable is set.
         If it is not set, it checks if both the compiler and the host support the feature.
         """
-        assert feature in ("cpp11", "cpp14", "cpp20", "sse2", "ssse3", "avx2", "avx512", "openmp", "native")
+        if feature not in ("cpp11", "cpp14", "cpp20", "sse2", "ssse3", "avx2", "avx512", "openmp", "native"):
+            raise ValueError("feature is not supported")
         try:
             return os.environ[f"HDF5PLUGIN_{feature.upper()}"] == "True"
         except KeyError:
@@ -656,7 +657,8 @@ class HDF5PluginExtension(Extension):
     def hdf5_plugin_name(self):
         """Return HDF5 plugin short name"""
         module_name = self.name.split('.')[-1]
-        assert module_name.startswith('libh5')
+        if not module_name.startswith('libh5'):
+            raise RuntimeError("Module name must start with libh5")
         return module_name[5:]  # Strip libh5
 
 
@@ -744,7 +746,8 @@ if BuildConfig.INTEL_IPP_DIR is not None:
 
 def _get_lz4_ipp_clib(field=None):
     """LZ4 static lib using Intel IPP build config"""
-    assert BuildConfig.INTEL_IPP_DIR is not None
+    if BuildConfig.INTEL_IPP_DIR is None:
+        raise RuntimeError("HDF5PLUGIN_INTEL_IPP_DIR env. var. must be set")
 
     cflags = ['-O3', '-ffast-math', '-std=gnu99']
     cflags += ['/Ox', '/fp:fast']

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 # /*##########################################################################
 #
 # Copyright (c) 2016-2025 European Synchrotron Radiation Facility
@@ -191,7 +190,7 @@ class HostConfig:
             return True
         return check_compile_flags(self.__compiler, '-std=c++14', extension='.cc')
 
-    @lru_cache()
+    @lru_cache
     def get_cpp20_flag(self) -> str | None:
         """Returns C++20 compiler flag or None if not supported"""
         if self.__compiler.compiler_type == 'msvc':
@@ -284,6 +283,7 @@ class HostConfig:
 
 class BuildConfig:
     """Describe build configuration"""
+
     def __init__(self, config_file: Path, compiler=None):
         self.__config_file = config_file
         self.__host_config = HostConfig(compiler)
@@ -471,7 +471,7 @@ class Build(build):
             ]
 
         if not self.hdf5plugin_config.use_cpp20:
-            cpp20_flags = set(["/std:c++20", "-std=c++20"])
+            cpp20_flags = {"/std:c++20", "-std=c++20"}
 
             # Filter out C++20 libraries
             self.distribution.libraries = [
@@ -508,6 +508,7 @@ class Build(build):
 
 class BuildPy(build_py):
     """build_py command also writing hdf5plugin._config"""
+
     def run(self):
         super().run()
         build_cmd = self.distribution.get_command_obj("build")
@@ -516,6 +517,7 @@ class BuildPy(build_py):
 
 class BuildCLib(build_clib):
     """build_clib command adding/patching compile args"""
+
     def build_libraries(self, libraries):
         updated_libraries = []
         for (lib_name, build_info) in libraries:
@@ -631,10 +633,9 @@ class HDF5PluginExtension(Extension):
                 glob(f"{self.include_dirs}/*.hpp")))
 
         self.export_symbols.append('H5PLget_plugin_info')
-        if not sys.platform == 'win32':
+        if sys.platform != 'win32':
             self.export_symbols.append('init_filter')
-
-        if sys.platform == 'win32':
+        else:
             self.define_macros.append(('H5_BUILT_AS_DYNAMIC_LIB', None))
             self.libraries.append('hdf5')
 
@@ -947,20 +948,20 @@ _EMBEDDED_CLIB_CONFIG_GETTERS = {
 _CLIB_NAMES = {"blosc", "blosc2"} | set(_EMBEDDED_CLIB_CONFIG_GETTERS.keys()) - {"sperr_filter"}
 
 
-@lru_cache()
+@lru_cache
 def get_system_clib_names():
     """Returns the set of clib names that should not be embedded"""
-    system_clibs = set(
+    system_clibs = {
         name.strip().lower()
         for name in os.environ.get('HDF5PLUGIN_SYSTEM_LIBRARIES', '').split(',')
         if name.strip()
-    )
+    }
     if not system_clibs <= _CLIB_NAMES:
         raise RuntimeError(f"Unexpected names in HDF5PLUGIN_SYSTEM_LIBRARIES: {system_clibs - _CLIB_NAMES}")
     return system_clibs
 
 
-@lru_cache()
+@lru_cache
 def _get_clib_config_from_pkgconfig(libname):
     if pkgconfig is None:
         raise RuntimeError("pkgconfig is required to build against system libraries")
@@ -1067,7 +1068,7 @@ def _get_blosc_plugin():
         sse2={'define_macros': [('SHUFFLE_SSE2_ENABLED', 1)]},
         avx2={'define_macros': [('SHUFFLE_AVX2_ENABLED', 1)]},
         cpp11=cpp11_kwargs,
-)
+    )
 
 
 if 'blosc' in get_system_clib_names():
@@ -1433,11 +1434,11 @@ def get_libraries_and_extensions():
 
     Strip libraries and extensions according to HDF5PLUGIN_STRIP env. var.
     """
-    stripped_filters = set(
+    stripped_filters = {
         name.strip().lower()
         for name in os.environ.get('HDF5PLUGIN_STRIP', '').split(',')
         if name.strip()
-    )
+    }
 
     if 'all' in stripped_filters:
         return [], []
@@ -1464,7 +1465,7 @@ def get_libraries_and_extensions():
     embedded_extension_names = PLUGIN_NAMES - stripped_filters
     extensions = [_EMBEDDED_PLUGIN_EXTENSIONS[name]() for name in embedded_extension_names]
 
-    if extensions and not sys.platform == 'win32':
+    if extensions and sys.platform != 'win32':
         # Add hdf5 dynamic loading lib
         libraries.append(
             (

--- a/setup.py
+++ b/setup.py
@@ -424,11 +424,9 @@ build_config = HDF5PluginBuildConfig(**{build_config})
 
     def has_config_changed(self) -> bool:
         """Returns whether config file needs to be changed or not."""
-        try:
-            return self.__config_file.read_text() != self.get_config_string()
-        except:  # noqa
-            pass
-        return True
+        if not self.__config_file.exists():
+            return True
+        return self.__config_file.read_text() != self.get_config_string()
 
     def save_config(self) -> None:
         """Save config as a dict in a python file"""

--- a/src/hdf5plugin/__init__.py
+++ b/src/hdf5plugin/__init__.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 # /*##########################################################################
 #
 # Copyright (c) 2016-2024 European Synchrotron Radiation Facility
@@ -23,7 +22,9 @@
 #
 # ###########################################################################*/
 """This module provides compiled shared libraries for their use as HDF5 filters
-under windows, MacOS and linux."""
+
+It works under Windows, MacOS and Linux.
+"""
 
 from ._version import version, version_info  # noqa
 

--- a/src/hdf5plugin/_filters.py
+++ b/src/hdf5plugin/_filters.py
@@ -103,8 +103,10 @@ class Bitshuffle(h5py.filters.FilterRefBase):
 
     def __init__(self, nelems=0, cname=None, clevel=3, lz4=None):
         nelems = int(nelems)
-        assert nelems % 8 == 0
-        assert clevel <= 22
+        if nelems % 8 != 0:
+            raise ValueError("nelems must be a multiple of 8")
+        if clevel > 22:
+            raise ValueError("clevel must be below or equal to 22")
 
         if lz4 is not None:
             if cname is not None and lz4 is not False:
@@ -180,8 +182,10 @@ class Blosc(h5py.filters.FilterRefBase):
     def __init__(self, cname='lz4', clevel=5, shuffle=SHUFFLE):
         compression = self.__COMPRESSIONS[cname]
         clevel = int(clevel)
-        assert 0 <= clevel <= 9
-        assert shuffle in (self.NOSHUFFLE, self.SHUFFLE, self.BITSHUFFLE)
+        if not 0 <= clevel <= 9:
+            raise ValueError("clevel must be in the range [0, 9]")
+        if shuffle not in (self.NOSHUFFLE, self.SHUFFLE, self.BITSHUFFLE):
+            raise ValueError(f"shuffle={shuffle} is not supported")
         self.filter_options = (0, 0, 0, 0, clevel, shuffle, compression)
 
 
@@ -240,8 +244,10 @@ class Blosc2(h5py.filters.FilterRefBase):
     def __init__(self, cname='blosclz', clevel=5, filters=SHUFFLE):
         compression = self.__COMPRESSIONS[cname]
         clevel = int(clevel)
-        assert 0 <= clevel <= 9
-        assert filters in (self.NOFILTER, self.SHUFFLE, self.BITSHUFFLE, self.DELTA, self.TRUNC_PREC)
+        if not 0 <= clevel <= 9:
+            raise ValueError("clevel must be in the range [0, 9]")
+        if filters not in (self.NOFILTER, self.SHUFFLE, self.BITSHUFFLE, self.DELTA, self.TRUNC_PREC):
+            raise ValueError(f"filters={filters} is not supported")
         self.filter_options = (0, 0, 0, 0, clevel, filters, compression)
 
 
@@ -264,7 +270,8 @@ class BZip2(h5py.filters.FilterRefBase):
 
     def __init__(self, blocksize=9) -> None:
         blocksize = int(blocksize)
-        assert 1 <= blocksize <= 9
+        if not 1 <= blocksize <= 9:
+            raise ValueError("blocksize must be in the range [1, 9]")
         self.filter_options = (blocksize,)
 
 
@@ -311,7 +318,8 @@ class LZ4(h5py.filters.FilterRefBase):
 
     def __init__(self, nbytes=0):
         nbytes = int(nbytes)
-        assert 0 <= nbytes <= 0x7E000000
+        if not 0 <= nbytes <= 0x7E000000:
+            raise ValueError("clevel must be in the range [0, 2113929216]")
         self.filter_options = (nbytes,)
 
 
@@ -523,15 +531,18 @@ class Sperr(h5py.filters.FilterRefBase):
             raise ValueError(f"Unsupported missing_value_mode: {missing_value_mode}")
 
         if peak_signal_to_noise_ratio is not None:
-            assert peak_signal_to_noise_ratio > 0
+            if peak_signal_to_noise_ratio <= 0:
+                raise ValueError("peak_signal_to_noise_ratio must be strictly positive")
             mode = 2
             quality = peak_signal_to_noise_ratio
         elif absolute is not None:
-            assert absolute > 0
+            if absolute <= 0:
+                raise ValueError("absolute must be strictly positive")
             mode = 3
             quality = absolute
         else:
-            assert rate is None or 0 < rate < 64
+            if rate is not None and not 0 < rate < 64:
+                raise ValueError("rate must be None or in the range ]0, 64[")
             mode = 1
             quality = 16 if rate is None else rate
 
@@ -539,8 +550,10 @@ class Sperr(h5py.filters.FilterRefBase):
 
     @classmethod
     def __pack_options(cls, mode: int, quality: float, swap: bool, missing_value_mode: int) -> tuple[int]:
-        assert mode in (1, 2, 3)
-        assert quality > 0
+        if mode not in (1, 2, 3):
+            raise ValueError("mode must be 1, 2 or 3")
+        if quality <= 0:
+            raise ValueError("quality must be strictly positive")
 
         if mode in (1, 2):
             ret = int(round(quality * (1 << cls._FRACTIONAL_BITS)))
@@ -748,7 +761,8 @@ class Zstd(h5py.filters.FilterRefBase):
     filter_id = ZSTD_ID
 
     def __init__(self, clevel=3):
-        assert 1 <= clevel <= 22
+        if not 1 <= clevel <= 22:
+            raise ValueError("clevel must be in the range [1, 22]")
         self.filter_options = (clevel,)
 
 

--- a/src/hdf5plugin/_filters.py
+++ b/src/hdf5plugin/_filters.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 # /*##########################################################################
 #
 # Copyright (c) 2016-2022 European Synchrotron Radiation Facility
@@ -92,6 +91,7 @@ class Bitshuffle(h5py.filters.FilterRefBase):
         Can be negative, and must be below or equal to 22 (maximum compression).
         Default: 3.
     """
+
     filter_name = "bshuf"
     filter_id = BSHUF_ID
 
@@ -265,6 +265,7 @@ class BZip2(h5py.filters.FilterRefBase):
 
     :param int blocksize: Size of the blocks as a multiple of 100k
     """
+
     filter_name = "bzip2"
     filter_id = BZIP2_ID
 
@@ -287,6 +288,7 @@ class FciDecomp(h5py.filters.FilterRefBase):
             compression=hdf5plugin.FciDecomp())
         f.close()
     """
+
     filter_name = "fcidecomp"
     filter_id = FCIDECOMP_ID
 
@@ -313,6 +315,7 @@ class LZ4(h5py.filters.FilterRefBase):
         It needs to be in the range of 0 < nbytes < 2113929216 (1,9GB).
         Default: 0 (for 1GB per block).
     """
+
     filter_name = "lz4"
     filter_id = LZ4_ID
 
@@ -402,6 +405,7 @@ class Zfp(h5py.filters.FilterRefBase):
     :param int minexp: Smallest absolute bit plane number encoded.
         It controls the absolute error.
     """
+
     filter_name = "zfp"
     filter_id = ZFP_ID
 
@@ -499,6 +503,7 @@ class Sperr(h5py.filters.FilterRefBase):
 
     For more details, see `H5Z-SPERR <https://github.com/NCAR/H5Z-SPERR>`_.
     """
+
     filter_name = "sperr"
     filter_id = SPERR_ID
 
@@ -524,7 +529,7 @@ class Sperr(h5py.filters.FilterRefBase):
             absolute: float | None = None,
             swap: bool = False,
             missing_value_mode: int = NO_MISSING,
-        ):
+    ):
         if (rate, peak_signal_to_noise_ratio, absolute).count(None) < 2:
             raise TypeError("hdf5plugin.Sperr() takes at most one not None argument")
         if missing_value_mode not in (self.NO_MISSING, self.MISSING_NAN, self.MISSING_1E35):
@@ -629,6 +634,7 @@ class SZ(h5py.filters.FilterRefBase):
 
     For more details about the compressor, see `SZ compressor <https://github.com/szcompressor/SZ>`_.
     """
+
     filter_name = "sz"
     filter_id = SZ_ID
 
@@ -687,6 +693,7 @@ class SZ3(h5py.filters.FilterRefBase):
        Backward compatibility is currently not guaranteed:
        See `this discussion <https://github.com/szcompressor/SZ3/issues/50#issuecomment-1901170917>`_.
     """
+
     filter_name = "sz3"
     filter_id = SZ3_ID
 
@@ -757,6 +764,7 @@ class Zstd(h5py.filters.FilterRefBase):
             compression=hdf5plugin.Zstd(clevel=22))
         f.close()
     """
+
     filter_name = "zstd"
     filter_id = ZSTD_ID
 
@@ -769,5 +777,5 @@ class Zstd(h5py.filters.FilterRefBase):
 FILTER_CLASSES = Bitshuffle, Blosc, Blosc2, BZip2, FciDecomp, LZ4, Sperr, SZ, SZ3, Zfp, Zstd
 
 
-FILTERS = dict((cls.filter_name, cls.filter_id) for cls in FILTER_CLASSES)
+FILTERS = {cls.filter_name: cls.filter_id for cls in FILTER_CLASSES}
 """Mapping of provided filter's name to their HDF5 filter ID."""

--- a/src/hdf5plugin/_utils.py
+++ b/src/hdf5plugin/_utils.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 # /*##########################################################################
 #
 # Copyright (c) 2016-2023 European Synchrotron Radiation Facility
@@ -99,10 +98,9 @@ def register_filter(name):
     # Unregister existing filter
     filter_id = FILTERS[name]
     is_avail = is_filter_available(name)
-    if is_avail is True:
-        if not h5py.h5z.unregister_filter(filter_id):
-            logger.error(f"Failed to unregister filter {name} ({filter_id})")
-            return False
+    if is_avail is True and not h5py.h5z.unregister_filter(filter_id):
+        logger.error(f"Failed to unregister filter {name} ({filter_id})")
+        return False
     if is_avail is None:  # Cannot probe filter availability
         try:
             h5py.h5z.unregister_filter(filter_id)

--- a/src/hdf5plugin/test.py
+++ b/src/hdf5plugin/test.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 # /*##########################################################################
 #
 # Copyright (c) 2019-2024 European Synchrotron Radiation Facility
@@ -22,7 +21,8 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
-"""Provides tests """
+"""Provides tests"""
+
 from __future__ import annotations
 
 import importlib.util
@@ -431,7 +431,7 @@ class TestGetFilters(unittest.TestCase):
         filters = hdf5plugin.get_filters("registered")
         self.assertTrue(set(filters).issubset(_filters.FILTER_CLASSES))
 
-        filter_names = set(f.filter_name for f in filters)
+        filter_names = {f.filter_name for f in filters}
         registered_names = set(hdf5plugin.get_config().registered_filters.keys())
         self.assertEqual(filter_names, registered_names)
 
@@ -508,22 +508,21 @@ class TestBlosc2Plugins(unittest.TestCase):
         )
 
         # Write blosc2 array as a hdf5 dataset
-        with io.BytesIO() as buffer:
-            with h5py.File(buffer, 'w') as f:
-                dataset = f.create_dataset(
-                    'data',
-                    shape=data.shape,
-                    dtype=data.dtype,
-                    chunks=data.shape,
-                    compression=hdf5plugin.Blosc2(),
-                )
-                dataset.id.write_direct_chunk(
-                    (0,) * data.ndim,
-                    blosc_array.schunk.to_cframe(),
-                )
-                f.flush()
+        with io.BytesIO() as buffer, h5py.File(buffer, 'w') as f:
+            dataset = f.create_dataset(
+                'data',
+                shape=data.shape,
+                dtype=data.dtype,
+                chunks=data.shape,
+                compression=hdf5plugin.Blosc2(),
+            )
+            dataset.id.write_direct_chunk(
+                (0,) * data.ndim,
+                blosc_array.schunk.to_cframe(),
+            )
+            f.flush()
 
-                return dataset[()]
+            return dataset[()]
 
     def test_blosc2_filter_int_trunc(self):
         """Read blosc2 dataset written with int truncate filter plugin"""

--- a/test/test.py
+++ b/test/test.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 # /*##########################################################################
 #
 # Copyright (c) 2016-2022 European Synchrotron Radiation Facility


### PR DESCRIPTION
This PR:
- fixes warnings raised by [bandit](https://github.com/PyCQA/bandit) security linter = replacing `assert` with exceptions outside of test code.
- updates the syntax with [`pyupgrade --py38-plus`](https://github.com/asottile/pyupgrade)
- adds bandit to the CI