### PR TITLE
Doc: Updated license syntax in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["py-cpuinfo==9.0.0", "setuptools>=62.4.0", "wheel>=0.34.0"]
+requires = ["py-cpuinfo==9.0.0", "setuptools>=77.0.0", "wheel>=0.34.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -10,7 +10,7 @@ authors = [
 description = "HDF5 Plugins for Windows, MacOS, and Linux"
 readme = "README.rst"
 requires-python = ">=3.9"
-license = {file = "LICENSE"}
+license-files = ["LICENSE"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
@@ -18,9 +18,6 @@ classifiers = [
     "Environment :: Win32 (MS Windows)",
     "Intended Audience :: Education",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
-    "License :: OSI Approved :: BSD License",
-    "License :: OSI Approved :: zlib/libpng License",
     "Natural Language :: English",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",


### PR DESCRIPTION
This PR updates the license info to avoid a warning during build.


closes #343