### PR TITLE
Updated minimum required version of Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build sdist & documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -35,28 +35,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
-            cibw_build: "cp38-manylinux_x86_64"
-          - os: windows-2019
-            cibw_build: "cp38-win_amd64"
-          - os: macos-13
-            cibw_build: "cp38-macosx_x86_64"
-          - os: ubuntu-latest
-            cibw_build: "cp310-manylinux_x86_64"
           - os: windows-latest
-            cibw_build: "cp311-win_amd64"
+            cibw_build: "cp39-win_amd64"
+          - os: ubuntu-latest
+            cibw_build: "cp312-manylinux_x86_64"
           - os: macos-latest
-            cibw_build: "cp312-macosx_arm64"
+            cibw_build: "cp313-macosx_arm64"
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: pypa/cibuildwheel@v2.23.0
+      - uses: actions/checkout@v5
+      - uses: pypa/cibuildwheel@v3.1.4
         env:
           MACOSX_DEPLOYMENT_TARGET: "10.13"
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_TEST_EXTRAS: "test"
-          # Test twice: with latest version and with numpy v1 and oldest supported h5py
+          # Test twice:
+          # - with latest version
+          # - with numpy v1 (for Python<=3.12) and oldest supported h5py
           CIBW_TEST_COMMAND: >
             python {project}/test/test.py &&
             pip install -r {project}/ci/oldest_h5py.txt &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,16 +58,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             cibw_archs: "auto64"
             with_sse2: true
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04-arm
             cibw_archs: "aarch64"
             with_sse2: false
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             cibw_archs: "ppc64le"
             with_sse2: false
-          - os: windows-2019
+          - os: windows-2022
             cibw_archs: "auto64"
             with_sse2: true
           - os: macos-13
@@ -77,7 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && runner.arch == 'X64'
         with:
           platforms: all
       - uses: pypa/cibuildwheel@v2.23.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,9 +105,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
           # Use silx wheelhouse for ppc64le
-          # Use numpy<2 since a wheel for h5py v3.11 which supports numpy v2 is not available for aarch64
-          # see https://github.com/h5py/h5py/issues/2408
-          CIBW_BEFORE_TEST: pip install "numpy<2" h5py --only-binary ":all:" --find-links=https://www.silx.org/pub/wheelhouse/ --trusted-host=www.silx.org
+          CIBW_BEFORE_TEST: pip install h5py --only-binary ":all:" --find-links=https://www.silx.org/pub/wheelhouse/ --trusted-host=www.silx.org
           CIBW_TEST_COMMAND: python {project}/test/test.py
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build and test source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -31,7 +31,7 @@ jobs:
     name: Build documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -75,12 +75,12 @@ jobs:
             with_sse2: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: docker/setup-qemu-action@v3
         if: runner.os == 'Linux' && runner.arch == 'X64'
         with:
           platforms: all
-      - uses: pypa/cibuildwheel@v2.23.0
+      - uses: pypa/cibuildwheel@v3.1.4
         env:
           # Configure hdf5plugin build
           HDF5PLUGIN_OPENMP: "False"
@@ -132,12 +132,12 @@ jobs:
             OLDEST_DEPENDENCIES: 'h5py==3.12.1 numpy==2.1.0'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           pattern: cibw-wheels-*
           path: dist
@@ -166,7 +166,7 @@ jobs:
     # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
     # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           pattern: cibw-*
           path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,8 +98,8 @@ jobs:
           CIBW_ENVIRONMENT_PASS_LINUX: HDF5PLUGIN_OPENMP HDF5PLUGIN_NATIVE HDF5PLUGIN_SSE2 HDF5PLUGIN_SSSE3 HDF5PLUGIN_AVX2 HDF5PLUGIN_AVX512 HDF5PLUGIN_BMI2 HDF5PLUGIN_CPP11 HDF5PLUGIN_CPP14 HDF5PLUGIN_CPP20
 
           CIBW_BUILD_VERBOSITY: 1
-          # Use Python3.11 to build wheels that are compatible with all supported version of Python
-          CIBW_BUILD: cp311-*
+          # Use Python3.12 to build wheels that are compatible with all supported version of Python
+          CIBW_BUILD: cp312-*
           # Do not build for pypy and muslinux
           CIBW_SKIP: pp* *-musllinux_*
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
@@ -121,15 +121,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
-        python-version: ['3.8', '3.12']
+        python-version: ['3.9', '3.13']
         include:
-          - python-version: '3.8'
+          - python-version: '3.9'
             OLDEST_DEPENDENCIES: 'h5py==3.0.0 "numpy<2"'
-          - python-version: '3.8'
+          - python-version: '3.9'
             os: 'macos-latest'
             OLDEST_DEPENDENCIES: 'h5py==3.7.0 "numpy<2"'
-          - python-version: '3.12'
-            OLDEST_DEPENDENCIES: 'h5py==3.10.0 "numpy<2"'
+          - python-version: '3.13'
+            OLDEST_DEPENDENCIES: 'h5py==3.12.1 numpy==2.1.0'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,8 +100,8 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
           # Use Python3.12 to build wheels that are compatible with all supported version of Python
           CIBW_BUILD: cp312-*
-          # Do not build for pypy and muslinux
-          CIBW_SKIP: pp* *-musllinux_*
+          # Do not build for muslinux
+          CIBW_SKIP: "*-musllinux_*"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
           # Use silx wheelhouse for ppc64le

--- a/ci/oldest_h5py.txt
+++ b/ci/oldest_h5py.txt
@@ -1,5 +1,5 @@
-numpy < 2
+numpy < 2 ; python_version <= '3.12'
 h5py == 3.10.0 ; python_version == '3.12'
 h5py == 3.8.0 ; python_version == '3.11'
 h5py == 3.6.0 ; python_version == '3.10'
-h5py == 3.0.0 ; python_version <= '3.9'
+h5py == 3.0.0 ; python_version == '3.9'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "HDF5 Plugins for Windows, MacOS, and Linux"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {file = "LICENSE"}
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -44,8 +44,9 @@ doc = [
     "sphinx_rtd_theme",
 ]
 test = [
-    "blosc2>=2.5.1;python_version>='3.9'",
-    "blosc2-grok>=0.2.2;python_version>='3.9'",
+    "numpy<2 ; python_version == '3.9'",
+    "blosc2>=2.5.1",
+    "blosc2-grok>=0.2.2",
 ]
 
 [tool.setuptools]

--- a/src/hdf5plugin/_version.py
+++ b/src/hdf5plugin/_version.py
@@ -26,7 +26,7 @@
 from typing import NamedTuple
 import re
 
-version = "5.1.0"
+version = "6.0.0"
 
 
 class _VersionInfo(NamedTuple):


### PR DESCRIPTION
This PR updates the minimum required version of Python to 3.9.
This is needed for PR #344 which is needed so that it keeps working with `setuptools` released after February 2026...

The CI configs are updated to add python3.13 and remove 3.8.
This PR also updates those CI configs