### PR TITLE
Deprecated `hdf5plugin.version_info`

### DIFF
--- a/src/hdf5plugin/__init__.py
+++ b/src/hdf5plugin/__init__.py
@@ -26,6 +26,7 @@
 It works under Windows, MacOS and Linux.
 """
 
+from . import _version
 from ._filters import FILTERS  # noqa
 from ._filters import (  # noqa
     BLOSC2_ID,
@@ -52,7 +53,13 @@ from ._filters import (  # noqa
     Zstd,
 )
 from ._utils import PLUGIN_PATH, get_config, get_filters, register  # noqa
-from ._version import version, version_info  # noqa
+from ._version import version  # noqa
 
 # Backward compatibility
 PLUGINS_PATH = PLUGIN_PATH
+
+
+def __getattr__(name: str) -> _version.VersionInfo:
+    if name == "version_info":
+        return _version.get_version_info()
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/src/hdf5plugin/_version.py
+++ b/src/hdf5plugin/_version.py
@@ -23,13 +23,17 @@
 # ###########################################################################*/
 
 
+import logging
 import re
 from typing import NamedTuple
 
 version = "6.0.0"
 
 
-class _VersionInfo(NamedTuple):
+logger = logging.getLogger(__name__)
+
+
+class VersionInfo(NamedTuple):
     """Version information as a namedtuple"""
 
     major: int
@@ -39,7 +43,7 @@ class _VersionInfo(NamedTuple):
     serial: int = 0
 
     @classmethod
-    def from_string(cls, version: str) -> "_VersionInfo":
+    def from_string(cls, version: str) -> "VersionInfo":
         pattern = r"(?P<major>\d+)\.(?P<minor>\d+)\.(?P<micro>\d+)((?P<prerelease>a|b|rc)(?P<serial>\d+))?"
         match = re.fullmatch(pattern, version, re.ASCII)
         if match is None:
@@ -55,4 +59,8 @@ class _VersionInfo(NamedTuple):
         return cls(releaselevel=releaselevel, **version_fields)
 
 
-version_info = _VersionInfo.from_string(version)
+def get_version_info() -> VersionInfo:
+    logger.warning(
+        "hdf5plugin.version_info is deprecated, use hdf5plugin.version instead."
+    )
+    return VersionInfo.from_string(version)


### PR DESCRIPTION
No need to maintain code for parsing a version string, `packaging.version.Version` does it if needed.

closes #354