### PR TITLE
Fix: Low performance for lz4 decompression

### DIFF
--- a/lib/LZ4/H5Zlz4.c
+++ b/lib/LZ4/H5Zlz4.c
@@ -99,14 +99,15 @@ static size_t H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts,
             }
             else /* do the decompression */
             {
-#if LZ4_VERSION_NUMBER > 10300
-                int compressedBytes = LZ4_decompress_fast(rpos, roBuf, blockSize);
-#else
-                int compressedBytes = LZ4_uncompress(rpos, roBuf, blockSize);
-#endif
-                if(compressedBytes != compressedBlockSize)
+                int decompressedBytes = LZ4_decompress_safe(
+                        rpos,
+                        roBuf,
+                        compressedBlockSize,
+                        blockSize);
+                if (decompressedBytes < 0 || decompressedBytes != blockSize)
                 {
-                    printf("decompressed size not the same: %d, != %d\n", compressedBytes, compressedBlockSize);
+                    printf("decompression failed or wrong size: %d != %u\n",
+                           decompressedBytes, blockSize);
                     goto error;
                 }
             }


### PR DESCRIPTION
With the LZ4 version included in the pypi released with the lz4 decompression with hdf5plugin 4.1.0 - 6.0.0 via decompression via the lz4_decompress_fast method got substantially slower then in hdf5plugin < 4.1.0.
lz4 decompress_fast is also deprecated in the LZ4 1.9.0 release since it is unsafe and shall be replaced by lz4_decompress_safe.

Note: this drops support for older LZ4 versions or at least might slow down the decompression when using lz4 libraries < 1.9.0, which is irrelevant to the currently builds wheels that are released to pypi.

Resolves #326