### PR TITLE
HDF5-2 compatibility - always link to hdf5 library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -682,7 +682,7 @@ class HDF5PluginExtension(Extension):
             self.export_symbols.append("init_filter")
         else:
             self.define_macros.append(("H5_BUILT_AS_DYNAMIC_LIB", None))
-            self.libraries.append("hdf5")
+        self.libraries.append("hdf5")
 
         self.define_macros.append(("H5_USE_18_API", None))
 


### PR DESCRIPTION
In building for HDF5-2 compatibility at conda-forge, i found that globals like `H5_libinit_g` now need the library to be linked.

https://github.com/conda-forge/hdf5plugin-feedstock/pull/72