### PR TITLE
Bitshuffle: Fixed `clevel` argument supported range

### DIFF
--- a/src/hdf5plugin/_filters.py
+++ b/src/hdf5plugin/_filters.py
@@ -133,7 +133,7 @@ class Bitshuffle(FilterBase):
         Default: 0 (for about 8 kilobytes per block).
     :param cname: Compressor name.
     :param clevel: Compression level, used **only for "zstd"** compression.
-        Can be negative, and must be below or equal to 22 (maximum compression).
+        Must be between 0 (default level) and 22 (maximum compression).
         Default: 3.
     """
 
@@ -158,8 +158,8 @@ class Bitshuffle(FilterBase):
         nelems = int(nelems)
         if nelems % 8 != 0:
             raise ValueError("nelems must be a multiple of 8")
-        if clevel > 22:
-            raise ValueError("clevel must be below or equal to 22")
+        if not 0 <= clevel <= 22:
+            raise ValueError("clevel must be in range [0, 22]")
 
         if lz4 is not None:
             if cname is not None and lz4 is not False:

--- a/src/hdf5plugin/test.py
+++ b/src/hdf5plugin/test.py
@@ -206,6 +206,19 @@ class TestHDF5PluginRW(BaseTestHDF5PluginRW):
                         )
                         self.assertEqual(filter_[2][3:5], (nelems, compression_id))
 
+    @unittest.skipUnless(should_test("bshuf"), "Bitshuffle filter not available")
+    def testBitshuffleZstdCLevel(self):
+        """Write/read test with bitshuffle+zstd with different compression levels"""
+        for clevel in (0, 3, 22):
+            with self.subTest(clevel=clevel):
+                filter_ = self._test(
+                    "bshuf",
+                    numpy.int32,
+                    compressed=True,
+                    options={"cname": "zstd", "clevel": clevel},
+                )
+                self.assertEqual(filter_[2][3:6], (0, 3, clevel))
+
     @unittest.skipUnless(should_test("blosc"), "Blosc filter not available")
     def testBlosc(self):
         """Write/read test with blosc filter plugin"""


### PR DESCRIPTION
This PR corrects the docstring and adds a check of the passed `clevel` value (see https://github.com/silx-kit/hdf5plugin/issues/375#issuecomment-4488083987 for description of the issue with negative values).

It also adds a test with different clevel values.

closes #375
