### PR TITLE
Removed wheel deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["py-cpuinfo==9.0.0", "setuptools>=77.0.0", "wheel>=0.34.0"]
+requires = ["py-cpuinfo==9.0.0", "setuptools>=77.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -40,12 +40,12 @@ from glob import glob
 from pathlib import Path
 
 from setuptools import Distribution, Extension, setup
+from setuptools.command.bdist_wheel import bdist_wheel
 from setuptools.command.build import build
 from setuptools.command.build_clib import build_clib
 from setuptools.command.build_ext import build_ext
 from setuptools.command.build_py import build_py
 from setuptools.errors import CompileError
-from wheel.bdist_wheel import bdist_wheel
 
 try:
     import pkgconfig


### PR DESCRIPTION
Since `hdf5plugin` requires, setuptools>=77.0.0, replace using `wheel` with `setuptools` which now (>=70.1) provides `bdist_wheel` to remove deprecation warning

closes #389