### PR TITLE
Compatibility to build against hdf5 v2

### DIFF
--- a/lib/hdf5_dl.c
+++ b/lib/hdf5_dl.c
@@ -143,6 +143,15 @@ static struct {
 
 
 /*HDF5 variables*/
+#define DEF_DEFAULT_BOOL_VARIABLE(NAME)\
+    _Bool NAME = -1
+
+#define DEF_DLSYM_BOOL_VARIABLE(NAME)\
+    NAME = *((_Bool *)dlsym(handle, #NAME))
+
+DEF_DEFAULT_BOOL_VARIABLE(H5_libinit_g);
+DEF_DEFAULT_BOOL_VARIABLE(H5_libterm_g);
+
 #define DEF_DEFAULT_VARIABLE(NAME)\
     hid_t NAME = -1
 
@@ -230,6 +239,9 @@ int init_filter(const char* libname)
     DL_H5Functions.H5Zunregister = (DL_func_H5Zunregister)dlsym(handle, "H5Zunregister");
 
     /*Variables*/
+    DEF_DLSYM_BOOL_VARIABLE(H5_libinit_g);
+    DEF_DLSYM_BOOL_VARIABLE(H5_libterm_g);
+
     DEF_DLSYM_VARIABLE(H5E_ARGS_g);
     DEF_DLSYM_VARIABLE(H5E_BADTYPE_g);
     DEF_DLSYM_VARIABLE(H5E_BADVALUE_g);


### PR DESCRIPTION
This PR adds missing variables that are accessed by the hdf5 plugins when built against libhdf5 v2. This occurs when building with `HDF5PLUGIN_HDF5_DIR` env. var. as in [conda-forge feedstock](https://github.com/conda-forge/hdf5plugin-feedstock/blob/994dbb7bf5c4e2bb6e734d5510af95cc8ec3dd9b/recipe/build.sh#L3)
Without this, filters built against libhdf5 v2 cannot be loaded.

Filters built against hdf5 v2 do NOT work with hdf5 v1. By default, filters are built against hdf5 v1 and works with hdf5 v2.

Alternative to PR #380