### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           - os: ubuntu-latest
             cibw_build: "cp312-manylinux_x86_64"
           - os: macos-latest
-            cibw_build: "cp313-macosx_arm64"
+            cibw_build: "cp314-macosx_arm64"
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     name: Build sdist & documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -47,8 +47,8 @@ jobs:
             cibw_build: "cp314-macosx_arm64"
 
     steps:
-      - uses: actions/checkout@v5
-      - uses: pypa/cibuildwheel@v3.1.4
+      - uses: actions/checkout@v7
+      - uses: pypa/cibuildwheel@v4.1.0
         env:
           MACOSX_DEPLOYMENT_TARGET: "10.13"
           CIBW_BUILD_VERBOSITY: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ jobs:
     name: Build and test source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -22,17 +22,17 @@ jobs:
       - run: python -m twine check dist/*
       - run: pip install --pre "$(ls dist/hdf5plugin*.tar.gz)[test]"
       - run: python test/test.py
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
-          name: cibw-sdist
-          path: dist/*.tar.gz
+          path: dist/hdf5plugin-*.tar.gz
+          archive: false
 
   build_doc:
     name: Build documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: "pip"
@@ -45,10 +45,10 @@ jobs:
           export OUTPUT_NAME="hdf5plugin-$(python -c 'import hdf5plugin; print(hdf5plugin.version)')_documentation"
           sphinx-build doc/ "${OUTPUT_NAME}/"
           zip -r "${OUTPUT_NAME}.zip" "${OUTPUT_NAME}/"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
-          name: documentation
           path: hdf5plugin-*_documentation.zip
+          archive: false
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}-${{ matrix.cibw_archs }}
@@ -78,12 +78,12 @@ jobs:
             with_sse2: false
 
     steps:
-      - uses: actions/checkout@v5
-      - uses: docker/setup-qemu-action@v3
+      - uses: actions/checkout@v7
+      - uses: docker/setup-qemu-action@v4
         if: runner.os == 'Linux' && runner.arch == 'X64'
         with:
           platforms: all
-      - uses: pypa/cibuildwheel@v3.3.1
+      - uses: pypa/cibuildwheel@v4.1.0
         env:
           # Configure hdf5plugin build
           HDF5PLUGIN_OPENMP: "False"
@@ -110,10 +110,10 @@ jobs:
           CIBW_TEST_SKIP: "*-*linux_ppc64le"
           CIBW_BEFORE_TEST: pip install h5py --only-binary ":all:"
           CIBW_TEST_COMMAND: python {project}/test/test.py
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
-          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
-          path: ./wheelhouse/*.whl
+          path: ./wheelhouse/hdf5plugin-*.whl
+          archive: false
 
   test_wheels:
     needs: [build_wheels]
@@ -137,16 +137,17 @@ jobs:
             OLDEST_DEPENDENCIES: 'h5py==3.15.1 numpy==2.4.1'
 
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v8
         with:
-          pattern: cibw-wheels-*
+          pattern: hdf5plugin-*.whl
           path: dist
           merge-multiple: true
+          skip-decompress: true
       - name: Install hdf5plugin
         # First select the right wheel from dist/ with pip download, then install it
         run: |
@@ -171,9 +172,10 @@ jobs:
     # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
     # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v8
         with:
-          pattern: cibw-*
+          pattern: hdf5plugin-*.{whl,tar.gz}
           path: dist
           merge-multiple: true
+          skip-decompress: true
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
           CIBW_TEST_SKIP: "*-*linux_ppc64le"
-          CIBW_BEFORE_TEST: pip install h5py --only-binary ":all:"
+          CIBW_BEFORE_TEST: pip install packaging h5py --only-binary ":all:"
           CIBW_TEST_COMMAND: python {project}/test/test.py
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
       - run: python -m build --sdist
       - run: python -m twine check dist/*
       - run: pip install --pre "$(ls dist/hdf5plugin*.tar.gz)[test]"
+      - run: pip uninstall -y blosc2_grok  # https://github.com/silx-kit/hdf5plugin/issues/377
       - run: python test/test.py
       - uses: actions/upload-artifact@v7
         with:
@@ -153,6 +154,7 @@ jobs:
         run: |
           pip download --no-index --no-cache --no-deps --find-links=./dist --only-binary :all: hdf5plugin
           pip install "$(ls ./hdf5plugin-*.whl)[test]"
+          pip uninstall -y blosc2_grok  # https://github.com/silx-kit/hdf5plugin/issues/377
       - name: Run test with latest h5py
         run: python test/test.py
       - name: Run test with oldest h5py

--- a/ci/oldest_h5py.txt
+++ b/ci/oldest_h5py.txt
@@ -1,4 +1,6 @@
 numpy < 2 ; python_version <= '3.12'
+h5py == 3.15.0 ; python_version == '3.14'
+h5py == 3.12.1 ; python_version == '3.13'
 h5py == 3.10.0 ; python_version == '3.12'
 h5py == 3.8.0 ; python_version == '3.11'
 h5py == 3.6.0 ; python_version == '3.10'

--- a/test/test.py
+++ b/test/test.py
@@ -68,8 +68,9 @@ class TestHDF5PluginRead(unittest.TestCase):
         self.assertTrue(data.shape[1] == 100, "Incorrect shape")
         self.assertTrue(data.shape[2] == 100, "Incorrect shape")
 
-        target = numpy.arange(numpy.prod(expected_shape), dtype=numpy.float64)
-        target.shape = expected_shape
+        target = numpy.arange(numpy.prod(expected_shape), dtype=numpy.float64).reshape(
+            expected_shape
+        )
         self.assertTrue(numpy.allclose(data, target), "Incorrect readout")
 
     @unittest.skipUnless(
@@ -304,10 +305,9 @@ class TestHDF5PluginRead(unittest.TestCase):
             )
 
             # see what relative and absolute differences are acceptable for this mode
-            difference = original - compressed_back
+            difference = numpy.ravel(original - compressed_back)
             idx = numpy.argmax(abs(difference))
-            difference.shape = -1
-            rtol = abs(difference[idx] / original.flatten()[idx])
+            rtol = abs(difference[idx] / numpy.ravel(original)[idx])
 
             # TODO: Check why one needs to have such large tolerance
             rtol = rtol * 5


### PR DESCRIPTION
This PR:
- Update CI to test py314 rather than py313
- Update actions and avoid compression of uploaded artifacts, since they are already compressed
- Fixed missing installed dependencies in CI (to be reworked once #377 is fixed)
- Fixed numpy deprecation warning