### PR TITLE
Doc: add `Example of an installation with conda for test` in contribute

### DIFF
--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -7,6 +7,7 @@ This project follows the standard open-source project github workflow, which is 
 Testing
 =======
 
+
 To run self-contained tests, from Python:
 
 .. code-block:: python
@@ -23,6 +24,36 @@ To also run tests relying on actual HDF5 files, run from the source directory::
   python test/test.py
 
 This tests the installed version of `hdf5plugin`.
+
+Example of an installation with conda for test
+..............................................
+
+1. `Install conda <https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html>`_ if needed & create conda environment for testing
+
+.. code-block:: bash
+
+  conda create -n hdf5plugins_env python=3.XX
+  conda activate hdf5plugins_env
+
+2. Install requirements
+
+.. code-block:: bash
+
+  conda install compilers
+  pip install py-cpuinfo setuptools
+
+3. Build
+
+.. code-block:: bash
+
+  python setup.py build
+
+4. Run the test
+
+.. code-block:: bash
+
+  PYTHONPATH=build/lib.linux-x86_64-cpython-3{XX}/ python test/test.py -vvv
+
 
 Formatting/Linting
 ==================


### PR DESCRIPTION
This PR add a documentation in `contribute` to give some hint on how to set up a conda env for testing / dev.

It has been added to `contribute` section but it can be moved somewhere else.

<img width="677" height="897" alt="image" src="https://github.com/user-attachments/assets/0ce092af-1d2c-42ce-8e7b-229e0aee6275" />
