### PR TITLE
Updated hdf5-blosc2 version in documentation

### DIFF
--- a/doc/information.rst
+++ b/doc/information.rst
@@ -69,8 +69,7 @@ HDF5 compression filters and compression libraries sources were obtained from:
   using `BZip2 <https://sourceware.org/git/bzip2.git>`_ (v1.0.8).
 * `hdf5-blosc plugin <https://github.com/Blosc/hdf5-blosc>`_ (v1.0.1)
   using `c-blosc <https://github.com/Blosc/c-blosc>`_ (v1.21.6), LZ4, Snappy, ZLib and ZStd.
-* `hdf5-blosc2 plugin <https://github.com/Blosc/HDF5-Blosc2>`_
-  (commit `e4d0f58 <https://github.com/Blosc/HDF5-Blosc2/tree/e4d0f583f39bf1d3e482aa4695b7dc95afb2b9b2>`_)
+* `hdf5-blosc2 plugin <https://github.com/Blosc/HDF5-Blosc2>`_ (v3.0.0)
   using `c-blosc2 <https://github.com/Blosc/c-blosc2>`_ (v3.1.4), LZ4, ZFP, ZLib and ZStd.
 * `FCIDECOMP plugin <https://gitlab.eumetsat.int/open-source/data-tailor-plugins/fcidecomp>`_
   (`v2.1.1 <https://gitlab.eumetsat.int/open-source/data-tailor-plugins/fcidecomp/-/tree/2.1.1>`_)


### PR DESCRIPTION
A [v3.0.0 tag](https://github.com/Blosc/HDF5-Blosc2/releases/tag/v3.0.0) has been set on the version of hdf5-blosc2 embedded in hdf5plugin, let's reference it in the documentation.