### PR TITLE
Add error checking to zstd HDF5 filter

### DIFF
--- a/lib/hdf5_plugins/ZSTD/src/H5Zzstd.c
+++ b/lib/hdf5_plugins/ZSTD/src/H5Zzstd.c
@@ -66,10 +66,16 @@ H5Z_filter_zstd(unsigned int flags, size_t cd_nelmts, const unsigned int cd_valu
     if (flags & H5Z_FLAG_REVERSE) {
         /* We're decompressing */
         size_t decompSize = ZSTD_getFrameContentSize(*buf, origSize);
+        if (decompSize == 0 || decompSize == ZSTD_CONTENTSIZE_UNKNOWN ||
+            decompSize == ZSTD_CONTENTSIZE_ERROR)
+            goto error;
+
         if (NULL == (outbuf = malloc(decompSize)))
             goto error;
 
         decompSize = ZSTD_decompress(outbuf, decompSize, inbuf, origSize);
+        if (ZSTD_isError(decompSize))
+            goto error;
 
 #ifdef ZSTD_DEBUG
         fprintf(stderr, "   decompressing nbytes: %ld\n", decompSize);
@@ -104,6 +110,8 @@ H5Z_filter_zstd(unsigned int flags, size_t cd_nelmts, const unsigned int cd_valu
             goto error;
 
         compSize = ZSTD_compress(outbuf, compSize, inbuf, origSize, aggression);
+        if (ZSTD_isError(compSize))
+            goto error;
 
 #ifdef ZSTD_DEBUG
         fprintf(stderr, "    compressing nbytes: %ld\n", compSize);


### PR DESCRIPTION
This PR adds error checking to the zstd HDF5 filter.  Previously it would return uninitialized memory from malloc when any zstd error occurred.

It also prevents proceeding with the result of `malloc(0)` in the abnormal case where `decompSize == 0`.